### PR TITLE
wrap query param with isset($uri["query"])

### DIFF
--- a/src/Cloudinary.php
+++ b/src/Cloudinary.php
@@ -28,7 +28,9 @@ class Cloudinary {
         if ($cloudinary_url) {
             $uri = parse_url($cloudinary_url);
             $q_params = array();
-            parse_str($uri["query"], $q_params);
+            if (isset($uri["query"])) {
+                parse_str($uri["query"], $q_params);
+            }
             $config = array_merge($q_params, array(
                             "cloud_name" => $uri["host"],
                             "api_key" => $uri["user"],


### PR DESCRIPTION
This line throwed a notice when used via Cloudcontrol. Hope this makes sense :)
