### PR TITLE
Tweak to add support for load balanced set ups

### DIFF
--- a/src/Cloudinary.php
+++ b/src/Cloudinary.php
@@ -339,7 +339,10 @@ function cloudinary_url($source, $options = array()) {
     return cloudinary_url_internal($source, $options);
 }
 function cloudinary_url_internal($source, &$options = array()) {
-    if (!isset($options["secure"])) $options["secure"] = ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' );
+    if (!isset($options["secure"])) {
+        $options["secure"] = ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' )
+            || ( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' );
+    }
 
     return Cloudinary::cloudinary_url($source, $options);
 }


### PR DESCRIPTION
Added support for load balancers that send along `https` status via the `HTTP_X_FORWARDED_PROTO` header
@see http://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Common_non-standard_request_headers
