### PR TITLE
Fixing HHVM Compatibility Issue

### DIFF
--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -245,6 +245,7 @@ namespace Cloudinary {
                 if (!preg_match('/^@|^https?:|^s3:|^data:[^;]*;base64,([a-zA-Z0-9\/+\n=]+)$/', $file)) {
                     if (function_exists("curl_file_create")) {
                         $post_params['file'] = curl_file_create($file);
+                        $post_params['file']->setPostFilename($file);
                     } else {
                         $post_params["file"] = "@" . $file;
                     }


### PR DESCRIPTION
For some reason, in HHVM, the `CURLFile` object doesn't set the `$postname` attribute automatically. This makes the Cloudinary API reject the file, and suggest that it isn't present at all. Simply called `CURLFile::setPostFilename($name)` when preparing the CURL request.
