### PR TITLE
Added 2 new parameters to the build_archive_params function

### DIFF
--- a/src/Cloudinary.php
+++ b/src/Cloudinary.php
@@ -748,6 +748,8 @@ class Cloudinary {
             "public_ids" => \Cloudinary::build_array(\Cloudinary::option_get($options, "public_ids")),
             "prefixes" => \Cloudinary::build_array(\Cloudinary::option_get($options, "prefixes")),
             "transformations" => \Cloudinary::build_eager(\Cloudinary::option_get($options, "transformations")),
+            "skip_transformation_name" => \Cloudinary::option_get($options, "skip_transformation_name"),
+            "allow_missing" => \Cloudinary::option_get($options, "allow_missing")
         );
         array_walk($params, function (&$value, $key){ $value = (is_bool($value) ? ($value ? "1" : "0") : $value);});
         return array_filter($params,function($v){ return !is_null($v) && ($v !== "" );});


### PR DESCRIPTION
While communicating with Itay he gave us the option to include 2 new parameters when using the create_archive function. These parameters were

- skip_transformation_name (a true value will result in all files found in a zip download having their original name rather than the version that contains all transformations. a false value will include said transformations on the end of the file names)
- allow_missing (a true value will allow any missing files to be skipped when generating a zip file. These missing files will then be returned in the callback function. A false value will ensure that every file requested is present. Any missing files will cause an error to be returned through the callback)