### PR TITLE
Fixed an issue on locales that use a comma as decimal separator

### DIFF
--- a/src/Cloudinary.php
+++ b/src/Cloudinary.php
@@ -490,6 +490,9 @@ class Cloudinary {
     }
 
     private static function normalize_expression($exp) {
+      if (is_float($exp)) {
+          return number_format($exp, 1);
+      }
       if (preg_match('/^!.+!$/', $exp)) {
         return $exp;
       } else {


### PR DESCRIPTION
If you are using a locale that has a comma as decimal separator, it breaks the url generation. The purpose of this pull request is to fix this issue.
Example:
```php
cloudinary_url('my_pic', ['zoom' => 0.7]);
// Result: http://res.cloudinary.com/xxx/image/upload/z_0,7/my_pic.jpg
// Should be: http://res.cloudinary.com/xxx/image/upload/z_0.7/my_pic.jpg
```