### PR TITLE
Fixes issue where requests with non-valid url characters would break

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -308,7 +308,7 @@ class Api {
     if (!$api_key) throw new \InvalidArgumentException("Must supply api_key");
     $api_secret = \Cloudinary::option_get($options, "api_secret", \Cloudinary::config_get("api_secret"));
     if (!$api_secret) throw new \InvalidArgumentException("Must supply api_secret");
-    $api_url = implode("/", array_merge(array($prefix, "v1_1", $cloud_name), $uri));
+    $api_url = implode("/", array_merge(array($prefix, "v1_1", $cloud_name), array_map('rawurlencode', $uri)));
     $params = array_filter($params,function($v){ return !is_null($v) && ($v !== "" );});
     if ($method == "get")
     {


### PR DESCRIPTION
If you make an update-request to an item with a public_id consisting of non-valid url characters (e.g. space), the request would fail.
Using the update function in Api.php with the public_id "Kremet brokkolisalat" would return a 400 status.
Url-encoding the parts of the requested url fixes this.