### PR TITLE
Fix edge case handling in `norm_range_value` function

### DIFF
--- a/src/Cloudinary.php
+++ b/src/Cloudinary.php
@@ -617,8 +617,14 @@ class Cloudinary
 
     private static function norm_range_value($value)
     {
-        if (empty($value)) {
-            return null;
+        if (is_null($value)) {
+          return null;
+        }
+
+        // Ensure that trailing decimal(.0) part is not cropped when float is provided
+        // e.g. float 1.0 should be returned as "1.0" and not "1" as it happens by default
+        if (is_float($value) && $value - (int)$value == 0) {
+            $value = sprintf("%.1f", $value);
         }
 
         preg_match(Cloudinary::RANGE_VALUE_RE, $value, $matches);

--- a/tests/CloudinaryTest.php
+++ b/tests/CloudinaryTest.php
@@ -968,13 +968,24 @@ class CloudinaryTest extends TestCase
         $method->setAccessible(true);
         // should parse integer range values
         $this->assertEquals($method->invoke(null, "200"), "200");
+        $this->assertEquals($method->invoke(null, 200), "200");
+        $this->assertEquals($method->invoke(null, 0), "0");
         // should parse float range values
         $this->assertEquals($method->invoke(null, "200.0"), "200.0");
+        $this->assertEquals($method->invoke(null, 200.0), "200.0");
+        $this->assertEquals($method->invoke(null, 200.00), "200.0");
+        $this->assertEquals($method->invoke(null, 200.123), "200.123");
+        $this->assertEquals($method->invoke(null, 200.123000), "200.123");
+        $this->assertEquals($method->invoke(null, 0.0), "0.0");
         // should parse a percent range value
         $this->assertEquals($method->invoke(null, "20p"), "20p");
         $this->assertEquals($method->invoke(null, "20P"), "20p");
         $this->assertEquals($method->invoke(null, "20%"), "20p");
+        $this->assertEquals($method->invoke(null, "20.5%"), "20.5p");
+        // should handle invalid input
         $this->assertNull($method->invoke(null, "p"));
+        $this->assertNull($method->invoke(null, ""));
+        $this->assertNull($method->invoke(null, null));
     }
 
     public function test_video_codec()


### PR DESCRIPTION
Allow providing 0(integer) value
Make float values behave the same as in other SDKs
Add unit tests to cover edge cases