### PR TITLE
Fix for Uploader.php to prevent uploads failing

### DIFF
--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -107,7 +107,7 @@ namespace Cloudinary {
             $file_extension = pathinfo($file, PATHINFO_EXTENSION);
             $src = fopen($file, 'r');
             $temp_file_name = tempnam(sys_get_temp_dir(), 'cldupload.') .
-                              (!empty($file_extension)) ? "." . $file_extension : "";
+                              (!empty($file_extension) ? "." . $file_extension : "");
             $upload = null;
             $upload_id = \Cloudinary::random_public_id();
             $chunk_size = \Cloudinary::option_get($options, "chunk_size", 20000000);


### PR DESCRIPTION
The ternary operator has a bracket in the wrong place, which can cause uploads to fail.

For example, instead of "/tmp/cldupload.7Ua4gD.avi", I only get ".avi". This is because the incorrect bracket placement turns the entire first half of the string into the condition for the ternary operator, which evaluates to true, meaning the true part of the operator is used, which is just the extension.

Since the path is stripped completely, the temporary file is created in the current working directory, which the script may not have write access to. This causes a "Server returned unexpected status code - 0 - ", as the file chunk is not written, and can then not be read back for upload.

My change moves one bracket to encompass the entire ternary operator, which causes it to evaluate correctly, eliminating the issue.

Note that if the script does have write access to it's working directory, this issue will not occur, and the script will seem to work perfectly, even though it created a temporary file in the wrong place.