### PR TITLE
Prevent needless error-supression

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -36,7 +36,7 @@ namespace {
 
     function cl_upload_url($options = array())
     {
-        $options['resource_type'] = isset($options['resource_type']) ? $options['resource_type'] : 'auto';
+        $options['resource_type'] = Cloudinary::option_get($options, 'resource_type', 'auto');
         $endpoint = array_key_exists('chunk_size', $options) ? 'upload_chunked' : 'upload';
 
         return Cloudinary::cloudinary_api_url($endpoint, $options);

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -36,9 +36,7 @@ namespace {
 
     function cl_upload_url($options = array())
     {
-        if (!@$options["resource_type"]) {
-            $options["resource_type"] = "auto";
-        }
+        $options['resource_type'] = isset($options['resource_type']) ? $options['resource_type'] : 'auto';
         $endpoint = array_key_exists('chunk_size', $options) ? 'upload_chunked' : 'upload';
 
         return Cloudinary::cloudinary_api_url($endpoint, $options);


### PR DESCRIPTION
To prevent the following error when developing with a high error reporting level:


```php
Array
(
    [errorReportingLevel] => 0
    [errorNumber] => 8
    [errorMessage] => Undefined index: resource_type
    [filename] => /project/vendor/cloudinary/cloudinary_php/src/Helpers.php
    [lineNumber] => 39
)
```