### PR TITLE
Structured metadata administration

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -1327,6 +1327,189 @@ namespace Cloudinary {
         }
 
         /**
+         * Returns a list of all metadata field definitions
+         *
+         * @see https://cloudinary.com/documentation/admin_api#get_metadata_fields
+         *
+         * @return \Cloudinary\Api\Response
+         *
+         * @throws \Cloudinary\Api\GeneralError
+         */
+        public function list_metadata_fields()
+        {
+            $uri = ['metadata_fields'];
+            $options = array('content_type' => 'application/json');
+            return $this->call_api('get', $uri, array(), $options);
+        }
+
+        /**
+         * Get a metadata field by external id
+         *
+         * @see https://cloudinary.com/documentation/admin_api#get_a_metadata_field_by_external_id
+         *
+         * @param string $field_external_id The ID of the metadata field to retrieve
+         *
+         * @return \Cloudinary\Api\Response
+         * @throws \Cloudinary\Api\GeneralError
+         */
+        public function metadata_field_by_field_id($field_external_id)
+        {
+            $uri = ['metadata_fields', $field_external_id];
+            $options = array('content_type' => 'application/json');
+            return $this->call_api('get', $uri, array(), $options);
+        }
+
+        /**
+         * Add a new metadata field definition
+         *
+         * @see https://cloudinary.com/documentation/admin_api#create_a_metadata_field
+         *
+         * @param array $field The field to add
+         *
+         * @return \Cloudinary\Api\Response
+         *
+         * @throws \Cloudinary\Api\GeneralError
+         */
+        public function add_metadata_field(array $field)
+        {
+            $uri = ['metadata_fields'];
+            $params = $this->only($field, [
+                'type',
+                'external_id',
+                'label',
+                'mandatory',
+                'default_value',
+                'validation',
+                'datasource'
+            ]);
+            $options = array('content_type' => 'application/json');
+
+            return $this->call_api('post', $uri, $params, $options);
+        }
+
+        /**
+         * Updates a metadata field definition (partially, no need to pass the entire object)
+         *
+         * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_by_external_id
+         *
+         * @param string $field_external_id The id of the metadata field to update
+         * @param array $field The field definition
+         *
+         * @return \Cloudinary\Api\Response
+         *
+         * @throws \Cloudinary\Api\GeneralError
+         */
+        public function update_metadata_field($field_external_id, array $field)
+        {
+            $uri = ['metadata_fields', $field_external_id];
+            $params = $this->only($field, [
+                'label',
+                'mandatory',
+                'default_value',
+                'validation'
+            ]);
+            $options = array('content_type' => 'application/json');
+
+            return $this->call_api('put', $uri, $params, $options);
+        }
+
+        /**
+         * Deletes a metadata field definition.
+         * The field should no longer be considered a valid candidate for all other endpoints
+         *
+         * @see https://cloudinary.com/documentation/admin_api#delete_a_metadata_field_by_external_id
+         *
+         * @param string $field_external_id The external id of the field to delete
+         *
+         * @return \Cloudinary\Api\Response An array with a "message" key. "ok" value indicates a successful deletion.
+         *
+         * @throws \Cloudinary\Api\GeneralError
+         */
+        public function delete_metadata_field($field_external_id)
+        {
+            $uri = ['metadata_fields', $field_external_id];
+            $options = array('content_type' => 'application/json');
+
+            return $this->call_api('delete', $uri, array(), $options);
+        }
+
+        /**
+         * Deletes (blocks) the datasource entries for a specified metadata field definition. Sets the state of the
+         * entries to inactive. This is a soft delete, the entries still exist under the hood and can be activated again
+         * with the restore datasource entries method.
+         *
+         * @see https://cloudinary.com/documentation/admin_api#delete_entries_in_a_metadata_field_datasource
+         *
+         * @param string $field_external_id The id of the field to update
+         * @param array $entries_external_id The ids of all the entries to delete from the datasource
+         *
+         * @return \Cloudinary\Api\Response The remaining datasource entries.
+         *
+         * @throws \Cloudinary\Api\GeneralError
+         */
+        public function delete_datasource_entries($field_external_id, array $entries_external_id)
+        {
+            $uri = ['metadata_fields', $field_external_id, 'datasource'];
+            $params = ['external_ids' => $entries_external_id];
+            $options = array('content_type' => 'application/json');
+
+            return $this->call_api("delete", $uri, $params, $options);
+        }
+
+        /**
+         * Updates the datasource of a supported field type (currently only enum and set), passed as JSON data. The
+         * update is partial: datasource entries with an existing external_id will be updated and entries with new
+         * external_id’s (or without external_id’s) will be appended.
+         *
+         * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_datasource
+         *
+         * @param string $field_external_id The external id of the field to update
+         * @param array $entries_external_id
+         *
+         * @return \Cloudinary\Api\Response
+         *
+         * @throws \Cloudinary\Api\GeneralError
+         */
+        public function update_metadata_field_datasource($field_external_id, array $entries_external_id)
+        {
+            $uri = ['metadata_fields', $field_external_id, 'datasource'];
+            $params = array('values' => array());
+            foreach ($entries_external_id as $item) {
+                $item = $this->only($item, ['external_id', 'value']);
+                if (!empty($item)) {
+                    $params['values'][] = $item;
+                }
+            }
+            $options = array('content_type' => 'application/json');
+
+            return $this->call_api('put', $uri, $params, $options);
+        }
+
+        /**
+         * Restore entries in a metadata field datasource
+         *
+         * Restores (unblocks) any previously deleted datasource entries for a specified metadata field definition.
+         * Sets the state of the entries to active.
+         *
+         * @see https://cloudinary.com/documentation/admin_api#restore_entries_in_a_metadata_field_datasource
+         *
+         * @param string $field_external_id The ID of the metadata field
+         * @param array $entries_external_ids An array of IDs of datasource entries to restore (unblock)
+         *
+         * @return \Cloudinary\Api\Response
+         *
+         * @throws \Cloudinary\Api\GeneralError
+         */
+        public function restore_metadata_field_datasource($field_external_id, array $entries_external_ids)
+        {
+            $uri = ['metadata_fields', $field_external_id, 'datasource_restore'];
+            $params['external_ids'] = $entries_external_ids;
+            $options = ['content_type' => 'application/json'];
+
+            return $this->call_api('post', $uri, $params, $options);
+        }
+
+        /**
          * The core function that performs the API call
          *
          * Function validates configuration, builds query string/request body, performs request and returns result

--- a/src/Api.php
+++ b/src/Api.php
@@ -1339,9 +1339,7 @@ namespace Cloudinary {
          */
         public function list_metadata_fields($options = array())
         {
-            $uri = ['metadata_fields'];
-            $options['content_type'] = 'application/json';
-            return $this->call_api('get', $uri, array(), $options);
+            return $this->call_metadata_api('get', array(), array(), $options);
         }
 
         /**
@@ -1357,9 +1355,9 @@ namespace Cloudinary {
          */
         public function metadata_field_by_field_id($field_external_id, $options = array())
         {
-            $uri = ['metadata_fields', $field_external_id];
-            $options['content_type'] = 'application/json';
-            return $this->call_api('get', $uri, array(), $options);
+            $uri = [$field_external_id];
+
+            return $this->call_metadata_api('get', $uri, array(), $options);
         }
 
         /**
@@ -1376,7 +1374,6 @@ namespace Cloudinary {
          */
         public function add_metadata_field(array $field, $options = array())
         {
-            $uri = ['metadata_fields'];
             $params = $this->only($field, [
                 'type',
                 'external_id',
@@ -1386,9 +1383,8 @@ namespace Cloudinary {
                 'validation',
                 'datasource'
             ]);
-            $options['content_type'] = 'application/json';
 
-            return $this->call_api('post', $uri, $params, $options);
+            return $this->call_metadata_api('post', array(), $params, $options);
         }
 
         /**
@@ -1406,16 +1402,15 @@ namespace Cloudinary {
          */
         public function update_metadata_field($field_external_id, array $field, $options = array())
         {
-            $uri = ['metadata_fields', $field_external_id];
+            $uri = [$field_external_id];
             $params = $this->only($field, [
                 'label',
                 'mandatory',
                 'default_value',
                 'validation'
             ]);
-            $options['content_type'] = 'application/json';
 
-            return $this->call_api('put', $uri, $params, $options);
+            return $this->call_metadata_api('put', $uri, $params, $options);
         }
 
         /**
@@ -1433,10 +1428,9 @@ namespace Cloudinary {
          */
         public function delete_metadata_field($field_external_id, $options = array())
         {
-            $uri = ['metadata_fields', $field_external_id];
-            $options['content_type'] = 'application/json';
+            $uri = [$field_external_id];
 
-            return $this->call_api('delete', $uri, array(), $options);
+            return $this->call_metadata_api('delete', $uri, array(), $options);
         }
 
         /**
@@ -1456,11 +1450,10 @@ namespace Cloudinary {
          */
         public function delete_datasource_entries($field_external_id, array $entries_external_id, $options = array())
         {
-            $uri = ['metadata_fields', $field_external_id, 'datasource'];
+            $uri = [$field_external_id, 'datasource'];
             $params = ['external_ids' => $entries_external_id];
-            $options['content_type'] = 'application/json';
 
-            return $this->call_api("delete", $uri, $params, $options);
+            return $this->call_metadata_api("delete", $uri, $params, $options);
         }
 
         /**
@@ -1480,7 +1473,7 @@ namespace Cloudinary {
          */
         public function update_metadata_field_datasource($field_external_id, array $entries_external_id, $options = array())
         {
-            $uri = ['metadata_fields', $field_external_id, 'datasource'];
+            $uri = [$field_external_id, 'datasource'];
             $params = array('values' => array());
             foreach ($entries_external_id as $item) {
                 $item = $this->only($item, ['external_id', 'value']);
@@ -1488,9 +1481,8 @@ namespace Cloudinary {
                     $params['values'][] = $item;
                 }
             }
-            $options['content_type'] = 'application/json';
 
-            return $this->call_api('put', $uri, $params, $options);
+            return $this->call_metadata_api('put', $uri, $params, $options);
         }
 
         /**
@@ -1511,11 +1503,30 @@ namespace Cloudinary {
          */
         public function restore_metadata_field_datasource($field_external_id, array $entries_external_ids, $options = array())
         {
-            $uri = ['metadata_fields', $field_external_id, 'datasource_restore'];
+            $uri = [$field_external_id, 'datasource_restore'];
             $params['external_ids'] = $entries_external_ids;
+
+            return $this->call_metadata_api('post', $uri, $params, $options);
+        }
+
+        /**
+         * Private function that assists with performing an API call to the metadata_fields part of the Admin API
+         *
+         * @param string    $method    The HTTP method. Valid methods: get, post, put, delete
+         * @param array     $uri       REST endpoint of the API (without 'metadata_fields')
+         * @param array     $params    Query/body parameters passed to the method
+         * @param array     $options   Additional options. Can be an override of the configuration, headers, etc.
+         *
+         * @return Api\Response
+         *
+         * @throws Api\GeneralError
+         */
+        private function call_metadata_api($method, $uri, $params, &$options)
+        {
+            array_unshift($uri, 'metadata_fields');
             $options['content_type'] = 'application/json';
 
-            return $this->call_api('post', $uri, $params, $options);
+            return $this->call_api($method, $uri, $params, $options);
         }
 
         /**

--- a/src/Api.php
+++ b/src/Api.php
@@ -1337,7 +1337,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function list_metadata_fields(array $options = array())
+        public function list_metadata_fields($options = array())
         {
             return $this->call_metadata_api('get', array(), array(), $options);
         }
@@ -1354,7 +1354,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function metadata_field_by_field_id($field_external_id, array $options = array())
+        public function metadata_field_by_field_id($field_external_id, $options = array())
         {
             $uri = [$field_external_id];
 
@@ -1373,7 +1373,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function add_metadata_field(array $field, array $options = array())
+        public function add_metadata_field($field, $options = array())
         {
             $params = $this->only($field, [
                 'type',
@@ -1403,7 +1403,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function update_metadata_field($field_external_id, array $field, array $options = array())
+        public function update_metadata_field($field_external_id, $field, $options = array())
         {
             $uri = [$field_external_id];
             $params = $this->only($field, [
@@ -1430,7 +1430,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function delete_metadata_field($field_external_id, array $options = array())
+        public function delete_metadata_field($field_external_id, $options = array())
         {
             $uri = [$field_external_id];
 
@@ -1454,10 +1454,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function delete_datasource_entries(
-            $field_external_id,
-            array $entries_external_id,
-            array $options = array()
+        public function delete_datasource_entries($field_external_id, $entries_external_id, $options = array()
         )
         {
             $uri = [$field_external_id, 'datasource'];
@@ -1483,10 +1480,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function update_metadata_field_datasource(
-            $field_external_id,
-            array $entries_external_id,
-            array $options = array()
+        public function update_metadata_field_datasource($field_external_id, $entries_external_id, $options = array()
         )
         {
             $uri = [$field_external_id, 'datasource'];
@@ -1517,10 +1511,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function restore_metadata_field_datasource(
-            $field_external_id,
-            array $entries_external_ids,
-            array $options = array()
+        public function restore_metadata_field_datasource($field_external_id, $entries_external_ids, $options = array()
         )
         {
             $uri = [$field_external_id, 'datasource_restore'];
@@ -1541,7 +1532,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        private function call_metadata_api($method, array $uri, array $params, array &$options)
+        private function call_metadata_api($method, $uri, $params, array &$options)
         {
             array_unshift($uri, 'metadata_fields');
             $options['content_type'] = 'application/json';

--- a/src/Api.php
+++ b/src/Api.php
@@ -1347,8 +1347,8 @@ namespace Cloudinary {
          *
          * @see https://cloudinary.com/documentation/admin_api#get_a_metadata_field_by_external_id
          *
-         * @param string    $field_external_id  The ID of the metadata field to retrieve
-         * @param array     $options            Additional options
+         * @param string $field_external_id The ID of the metadata field to retrieve
+         * @param array  $options           Additional options
          *
          * @return Api\Response
          *
@@ -1366,8 +1366,8 @@ namespace Cloudinary {
          *
          * @see https://cloudinary.com/documentation/admin_api#create_a_metadata_field
          *
-         * @param array $field      The field to add
-         * @param array $options    Additional options
+         * @param array $field   The field to add
+         * @param array $options Additional options
          *
          * @return Api\Response
          *
@@ -1395,9 +1395,9 @@ namespace Cloudinary {
          *
          * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_by_external_id
          *
-         * @param string    $field_external_id  The id of the metadata field to update
-         * @param array     $field              The field definition
-         * @param array     $options            Additional options
+         * @param string $field_external_id The id of the metadata field to update
+         * @param array  $field             The field definition
+         * @param array  $options           Additional options
          *
          * @return Api\Response
          *
@@ -1423,8 +1423,8 @@ namespace Cloudinary {
          *
          * @see https://cloudinary.com/documentation/admin_api#delete_a_metadata_field_by_external_id
          *
-         * @param string    $field_external_id  The external id of the field to delete
-         * @param array     $options            Additional options
+         * @param string $field_external_id The external id of the field to delete
+         * @param array  $options           Additional options
          *
          * @return Api\Response An array with a "message" key. "ok" value indicates a successful deletion.
          *
@@ -1446,9 +1446,9 @@ namespace Cloudinary {
          *
          * @see https://cloudinary.com/documentation/admin_api#delete_entries_in_a_metadata_field_datasource
          *
-         * @param string    $field_external_id      The id of the field to update
-         * @param array     $entries_external_id    The ids of all the entries to delete from the datasource
-         * @param array     $options                Additional options
+         * @param string $field_external_id   The id of the field to update
+         * @param array  $entries_external_id The ids of all the entries to delete from the datasource
+         * @param array  $options             Additional options
          *
          * @return Api\Response The remaining datasource entries.
          *
@@ -1472,9 +1472,9 @@ namespace Cloudinary {
          *
          * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_datasource
          *
-         * @param string    $field_external_id      The external id of the field to update
-         * @param array     $entries_external_id
-         * @param array     $options                Additional options
+         * @param string $field_external_id The external id of the field to update
+         * @param array  $entries_external_id
+         * @param array  $options           Additional options
          *
          * @return Api\Response
          *
@@ -1503,9 +1503,9 @@ namespace Cloudinary {
          *
          * @see https://cloudinary.com/documentation/admin_api#restore_entries_in_a_metadata_field_datasource
          *
-         * @param string    $field_external_id      The ID of the metadata field
-         * @param array     $entries_external_ids   An array of IDs of datasource entries to restore (unblock)
-         * @param array     $options                Additional options
+         * @param string $field_external_id    The ID of the metadata field
+         * @param array  $entries_external_ids An array of IDs of datasource entries to restore (unblock)
+         * @param array  $options              Additional options
          *
          * @return Api\Response
          *
@@ -1523,10 +1523,10 @@ namespace Cloudinary {
         /**
          * Private function that assists with performing an API call to the metadata_fields part of the Admin API
          *
-         * @param string    $method    The HTTP method. Valid methods: get, post, put, delete
-         * @param array     $uri       REST endpoint of the API (without 'metadata_fields')
-         * @param array     $params    Query/body parameters passed to the method
-         * @param array     $options   Additional options. Can be an override of the configuration, headers, etc.
+         * @param string $method  The HTTP method. Valid methods: get, post, put, delete
+         * @param array  $uri     REST endpoint of the API (without 'metadata_fields')
+         * @param array  $params  Query/body parameters passed to the method
+         * @param array  $options Additional options. Can be an override of the configuration, headers, etc.
          *
          * @return Api\Response
          *

--- a/src/Api.php
+++ b/src/Api.php
@@ -1329,7 +1329,7 @@ namespace Cloudinary {
         /**
          * Returns a list of all metadata field definitions
          *
-         * @see https://cloudinary.com/documentation/admin_api#get_metadata_fields
+         * @see https://cloudinary.com/documentation/admin_api#get_metadata_fields Get metadata fields API reference
          *
          * @param array $options Additional options
          *
@@ -1345,7 +1345,7 @@ namespace Cloudinary {
         /**
          * Gets a metadata field by external id
          *
-         * @see https://cloudinary.com/documentation/admin_api#get_a_metadata_field_by_external_id
+         * @see https://cloudinary.com/documentation/admin_api#get_a_metadata_field_by_external_id Get metadata field by external ID API reference
          *
          * @param string $field_external_id The ID of the metadata field to retrieve
          * @param array  $options           Additional options
@@ -1364,7 +1364,7 @@ namespace Cloudinary {
         /**
          * Creates a new metadata field definition
          *
-         * @see https://cloudinary.com/documentation/admin_api#create_a_metadata_field
+         * @see https://cloudinary.com/documentation/admin_api#create_a_metadata_field Create metadata field API reference
          *
          * @param array $field   The field to add
          * @param array $options Additional options
@@ -1391,9 +1391,10 @@ namespace Cloudinary {
         /**
          * Updates a metadata field by external id
          *
-         * Updates a metadata field definition (partially, no need to pass the entire object)
+         * Updates a metadata field definition (partially, no need to pass the entire object) passed as JSON data.
+         * See {@see https://cloudinary.com/documentation/admin_api#generic_structure_of_a_metadata_field Generic structure of a metadata field} for details.
          *
-         * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_by_external_id
+         * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_by_external_id Update metadata field API reference
          *
          * @param string $field_external_id The id of the metadata field to update
          * @param array  $field             The field definition
@@ -1421,7 +1422,7 @@ namespace Cloudinary {
          *
          * The field should no longer be considered a valid candidate for all other endpoints
          *
-         * @see https://cloudinary.com/documentation/admin_api#delete_a_metadata_field_by_external_id
+         * @see https://cloudinary.com/documentation/admin_api#delete_a_metadata_field_by_external_id Delete metadata field API reference
          *
          * @param string $field_external_id The external id of the field to delete
          * @param array  $options           Additional options
@@ -1444,7 +1445,7 @@ namespace Cloudinary {
          * entries to inactive. This is a soft delete, the entries still exist under the hood and can be activated
          * again with the restore datasource entries method.
          *
-         * @see https://cloudinary.com/documentation/admin_api#delete_entries_in_a_metadata_field_datasource
+         * @see https://cloudinary.com/documentation/admin_api#delete_entries_in_a_metadata_field_datasource Delete entries in a metadata field datasource API reference
          *
          * @param string $field_external_id   The id of the field to update
          * @param array  $entries_external_id The ids of all the entries to delete from the datasource
@@ -1470,7 +1471,7 @@ namespace Cloudinary {
          * update is partial: datasource entries with an existing external_id will be updated and entries with new
          * external_id’s (or without external_id’s) will be appended.
          *
-         * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_datasource
+         * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_datasource Update a metadata field datasource API reference
          *
          * @param string $field_external_id The external id of the field to update
          * @param array  $entries_external_id
@@ -1501,7 +1502,7 @@ namespace Cloudinary {
          * Restores (unblocks) any previously deleted datasource entries for a specified metadata field definition.
          * Sets the state of the entries to active.
          *
-         * @see https://cloudinary.com/documentation/admin_api#restore_entries_in_a_metadata_field_datasource
+         * @see https://cloudinary.com/documentation/admin_api#restore_entries_in_a_metadata_field_datasource Restore entries in a metadata field datasource API reference
          *
          * @param string $field_external_id    The ID of the metadata field
          * @param array  $entries_external_ids An array of IDs of datasource entries to restore (unblock)

--- a/src/Api.php
+++ b/src/Api.php
@@ -1337,7 +1337,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function list_metadata_fields($options = array())
+        public function list_metadata_fields(array $options = array())
         {
             return $this->call_metadata_api('get', array(), array(), $options);
         }
@@ -1354,7 +1354,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function metadata_field_by_field_id($field_external_id, $options = array())
+        public function metadata_field_by_field_id($field_external_id, array $options = array())
         {
             $uri = [$field_external_id];
 
@@ -1373,7 +1373,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function add_metadata_field(array $field, $options = array())
+        public function add_metadata_field(array $field, array $options = array())
         {
             $params = $this->only($field, [
                 'type',
@@ -1403,7 +1403,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function update_metadata_field($field_external_id, array $field, $options = array())
+        public function update_metadata_field($field_external_id, array $field, array $options = array())
         {
             $uri = [$field_external_id];
             $params = $this->only($field, [
@@ -1430,7 +1430,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function delete_metadata_field($field_external_id, $options = array())
+        public function delete_metadata_field($field_external_id, array $options = array())
         {
             $uri = [$field_external_id];
 
@@ -1454,7 +1454,11 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function delete_datasource_entries($field_external_id, array $entries_external_id, $options = array())
+        public function delete_datasource_entries(
+            $field_external_id,
+            array $entries_external_id,
+            array $options = array()
+        )
         {
             $uri = [$field_external_id, 'datasource'];
             $params = ['external_ids' => $entries_external_id];
@@ -1479,7 +1483,11 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function update_metadata_field_datasource($field_external_id, array $entries_external_id, $options = array())
+        public function update_metadata_field_datasource(
+            $field_external_id,
+            array $entries_external_id,
+            array $options = array()
+        )
         {
             $uri = [$field_external_id, 'datasource'];
             $params = array('values' => array());
@@ -1509,7 +1517,11 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        public function restore_metadata_field_datasource($field_external_id, array $entries_external_ids, $options = array())
+        public function restore_metadata_field_datasource(
+            $field_external_id,
+            array $entries_external_ids,
+            array $options = array()
+        )
         {
             $uri = [$field_external_id, 'datasource_restore'];
             $params['external_ids'] = $entries_external_ids;
@@ -1529,7 +1541,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        private function call_metadata_api($method, $uri, $params, &$options)
+        private function call_metadata_api($method, array $uri, array $params, array &$options)
         {
             array_unshift($uri, 'metadata_fields');
             $options['content_type'] = 'application/json';

--- a/src/Api.php
+++ b/src/Api.php
@@ -1331,14 +1331,16 @@ namespace Cloudinary {
          *
          * @see https://cloudinary.com/documentation/admin_api#get_metadata_fields
          *
+         * @param array $options Additional options
+         *
          * @return \Cloudinary\Api\Response
          *
          * @throws \Cloudinary\Api\GeneralError
          */
-        public function list_metadata_fields()
+        public function list_metadata_fields($options = array())
         {
             $uri = ['metadata_fields'];
-            $options = array('content_type' => 'application/json');
+            $options['content_type'] = 'application/json';
             return $this->call_api('get', $uri, array(), $options);
         }
 
@@ -1348,14 +1350,15 @@ namespace Cloudinary {
          * @see https://cloudinary.com/documentation/admin_api#get_a_metadata_field_by_external_id
          *
          * @param string $field_external_id The ID of the metadata field to retrieve
+         * @param array $options Additional options
          *
          * @return \Cloudinary\Api\Response
          * @throws \Cloudinary\Api\GeneralError
          */
-        public function metadata_field_by_field_id($field_external_id)
+        public function metadata_field_by_field_id($field_external_id, $options = array())
         {
             $uri = ['metadata_fields', $field_external_id];
-            $options = array('content_type' => 'application/json');
+            $options['content_type'] = 'application/json';
             return $this->call_api('get', $uri, array(), $options);
         }
 
@@ -1365,12 +1368,13 @@ namespace Cloudinary {
          * @see https://cloudinary.com/documentation/admin_api#create_a_metadata_field
          *
          * @param array $field The field to add
+         * @param array $options Additional options
          *
          * @return \Cloudinary\Api\Response
          *
          * @throws \Cloudinary\Api\GeneralError
          */
-        public function add_metadata_field(array $field)
+        public function add_metadata_field(array $field, $options = array())
         {
             $uri = ['metadata_fields'];
             $params = $this->only($field, [
@@ -1382,7 +1386,7 @@ namespace Cloudinary {
                 'validation',
                 'datasource'
             ]);
-            $options = array('content_type' => 'application/json');
+            $options['content_type'] = 'application/json';
 
             return $this->call_api('post', $uri, $params, $options);
         }
@@ -1394,12 +1398,13 @@ namespace Cloudinary {
          *
          * @param string $field_external_id The id of the metadata field to update
          * @param array $field The field definition
+         * @param array $options Additional options
          *
          * @return \Cloudinary\Api\Response
          *
          * @throws \Cloudinary\Api\GeneralError
          */
-        public function update_metadata_field($field_external_id, array $field)
+        public function update_metadata_field($field_external_id, array $field, $options = array())
         {
             $uri = ['metadata_fields', $field_external_id];
             $params = $this->only($field, [
@@ -1408,7 +1413,7 @@ namespace Cloudinary {
                 'default_value',
                 'validation'
             ]);
-            $options = array('content_type' => 'application/json');
+            $options['content_type'] = 'application/json';
 
             return $this->call_api('put', $uri, $params, $options);
         }
@@ -1420,15 +1425,16 @@ namespace Cloudinary {
          * @see https://cloudinary.com/documentation/admin_api#delete_a_metadata_field_by_external_id
          *
          * @param string $field_external_id The external id of the field to delete
+         * @param array $options Additional options
          *
          * @return \Cloudinary\Api\Response An array with a "message" key. "ok" value indicates a successful deletion.
          *
          * @throws \Cloudinary\Api\GeneralError
          */
-        public function delete_metadata_field($field_external_id)
+        public function delete_metadata_field($field_external_id, $options = array())
         {
             $uri = ['metadata_fields', $field_external_id];
-            $options = array('content_type' => 'application/json');
+            $options['content_type'] = 'application/json';
 
             return $this->call_api('delete', $uri, array(), $options);
         }
@@ -1442,16 +1448,17 @@ namespace Cloudinary {
          *
          * @param string $field_external_id The id of the field to update
          * @param array $entries_external_id The ids of all the entries to delete from the datasource
+         * @param array $options Additional options
          *
          * @return \Cloudinary\Api\Response The remaining datasource entries.
          *
          * @throws \Cloudinary\Api\GeneralError
          */
-        public function delete_datasource_entries($field_external_id, array $entries_external_id)
+        public function delete_datasource_entries($field_external_id, array $entries_external_id, $options = array())
         {
             $uri = ['metadata_fields', $field_external_id, 'datasource'];
             $params = ['external_ids' => $entries_external_id];
-            $options = array('content_type' => 'application/json');
+            $options['content_type'] = 'application/json';
 
             return $this->call_api("delete", $uri, $params, $options);
         }
@@ -1465,12 +1472,13 @@ namespace Cloudinary {
          *
          * @param string $field_external_id The external id of the field to update
          * @param array $entries_external_id
+         * @param array $options Additional options
          *
          * @return \Cloudinary\Api\Response
          *
          * @throws \Cloudinary\Api\GeneralError
          */
-        public function update_metadata_field_datasource($field_external_id, array $entries_external_id)
+        public function update_metadata_field_datasource($field_external_id, array $entries_external_id, $options = array())
         {
             $uri = ['metadata_fields', $field_external_id, 'datasource'];
             $params = array('values' => array());
@@ -1480,7 +1488,7 @@ namespace Cloudinary {
                     $params['values'][] = $item;
                 }
             }
-            $options = array('content_type' => 'application/json');
+            $options['content_type'] = 'application/json';
 
             return $this->call_api('put', $uri, $params, $options);
         }
@@ -1495,16 +1503,17 @@ namespace Cloudinary {
          *
          * @param string $field_external_id The ID of the metadata field
          * @param array $entries_external_ids An array of IDs of datasource entries to restore (unblock)
+         * @param array $options Additional options
          *
          * @return \Cloudinary\Api\Response
          *
          * @throws \Cloudinary\Api\GeneralError
          */
-        public function restore_metadata_field_datasource($field_external_id, array $entries_external_ids)
+        public function restore_metadata_field_datasource($field_external_id, array $entries_external_ids, $options = array())
         {
             $uri = ['metadata_fields', $field_external_id, 'datasource_restore'];
             $params['external_ids'] = $entries_external_ids;
-            $options = ['content_type' => 'application/json'];
+            $options['content_type'] = 'application/json';
 
             return $this->call_api('post', $uri, $params, $options);
         }

--- a/src/Api.php
+++ b/src/Api.php
@@ -1533,7 +1533,7 @@ namespace Cloudinary {
          *
          * @throws Api\GeneralError
          */
-        private function call_metadata_api($method, $uri, $params, array &$options)
+        private function call_metadata_api($method, $uri, $params, &$options)
         {
             array_unshift($uri, 'metadata_fields');
             $options['content_type'] = 'application/json';

--- a/src/Api.php
+++ b/src/Api.php
@@ -1333,9 +1333,9 @@ namespace Cloudinary {
          *
          * @param array $options Additional options
          *
-         * @return \Cloudinary\Api\Response
+         * @return Api\Response
          *
-         * @throws \Cloudinary\Api\GeneralError
+         * @throws Api\GeneralError
          */
         public function list_metadata_fields($options = array())
         {
@@ -1343,15 +1343,16 @@ namespace Cloudinary {
         }
 
         /**
-         * Get a metadata field by external id
+         * Gets a metadata field by external id
          *
          * @see https://cloudinary.com/documentation/admin_api#get_a_metadata_field_by_external_id
          *
-         * @param string $field_external_id The ID of the metadata field to retrieve
-         * @param array $options Additional options
+         * @param string    $field_external_id  The ID of the metadata field to retrieve
+         * @param array     $options            Additional options
          *
-         * @return \Cloudinary\Api\Response
-         * @throws \Cloudinary\Api\GeneralError
+         * @return Api\Response
+         *
+         * @throws Api\GeneralError
          */
         public function metadata_field_by_field_id($field_external_id, $options = array())
         {
@@ -1361,16 +1362,16 @@ namespace Cloudinary {
         }
 
         /**
-         * Add a new metadata field definition
+         * Creates a new metadata field definition
          *
          * @see https://cloudinary.com/documentation/admin_api#create_a_metadata_field
          *
-         * @param array $field The field to add
-         * @param array $options Additional options
+         * @param array $field      The field to add
+         * @param array $options    Additional options
          *
-         * @return \Cloudinary\Api\Response
+         * @return Api\Response
          *
-         * @throws \Cloudinary\Api\GeneralError
+         * @throws Api\GeneralError
          */
         public function add_metadata_field(array $field, $options = array())
         {
@@ -1388,17 +1389,19 @@ namespace Cloudinary {
         }
 
         /**
+         * Updates a metadata field by external id
+         *
          * Updates a metadata field definition (partially, no need to pass the entire object)
          *
          * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_by_external_id
          *
-         * @param string $field_external_id The id of the metadata field to update
-         * @param array $field The field definition
-         * @param array $options Additional options
+         * @param string    $field_external_id  The id of the metadata field to update
+         * @param array     $field              The field definition
+         * @param array     $options            Additional options
          *
-         * @return \Cloudinary\Api\Response
+         * @return Api\Response
          *
-         * @throws \Cloudinary\Api\GeneralError
+         * @throws Api\GeneralError
          */
         public function update_metadata_field($field_external_id, array $field, $options = array())
         {
@@ -1415,16 +1418,17 @@ namespace Cloudinary {
 
         /**
          * Deletes a metadata field definition.
+         *
          * The field should no longer be considered a valid candidate for all other endpoints
          *
          * @see https://cloudinary.com/documentation/admin_api#delete_a_metadata_field_by_external_id
          *
-         * @param string $field_external_id The external id of the field to delete
-         * @param array $options Additional options
+         * @param string    $field_external_id  The external id of the field to delete
+         * @param array     $options            Additional options
          *
-         * @return \Cloudinary\Api\Response An array with a "message" key. "ok" value indicates a successful deletion.
+         * @return Api\Response An array with a "message" key. "ok" value indicates a successful deletion.
          *
-         * @throws \Cloudinary\Api\GeneralError
+         * @throws Api\GeneralError
          */
         public function delete_metadata_field($field_external_id, $options = array())
         {
@@ -1434,19 +1438,21 @@ namespace Cloudinary {
         }
 
         /**
+         * Deletes entries in a metadata field datasource
+         *
          * Deletes (blocks) the datasource entries for a specified metadata field definition. Sets the state of the
-         * entries to inactive. This is a soft delete, the entries still exist under the hood and can be activated again
-         * with the restore datasource entries method.
+         * entries to inactive. This is a soft delete, the entries still exist under the hood and can be activated
+         * again with the restore datasource entries method.
          *
          * @see https://cloudinary.com/documentation/admin_api#delete_entries_in_a_metadata_field_datasource
          *
-         * @param string $field_external_id The id of the field to update
-         * @param array $entries_external_id The ids of all the entries to delete from the datasource
-         * @param array $options Additional options
+         * @param string    $field_external_id      The id of the field to update
+         * @param array     $entries_external_id    The ids of all the entries to delete from the datasource
+         * @param array     $options                Additional options
          *
-         * @return \Cloudinary\Api\Response The remaining datasource entries.
+         * @return Api\Response The remaining datasource entries.
          *
-         * @throws \Cloudinary\Api\GeneralError
+         * @throws Api\GeneralError
          */
         public function delete_datasource_entries($field_external_id, array $entries_external_id, $options = array())
         {
@@ -1457,19 +1463,21 @@ namespace Cloudinary {
         }
 
         /**
+         * Updates a metadata field datasource
+         *
          * Updates the datasource of a supported field type (currently only enum and set), passed as JSON data. The
          * update is partial: datasource entries with an existing external_id will be updated and entries with new
          * external_id’s (or without external_id’s) will be appended.
          *
          * @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_datasource
          *
-         * @param string $field_external_id The external id of the field to update
-         * @param array $entries_external_id
-         * @param array $options Additional options
+         * @param string    $field_external_id      The external id of the field to update
+         * @param array     $entries_external_id
+         * @param array     $options                Additional options
          *
-         * @return \Cloudinary\Api\Response
+         * @return Api\Response
          *
-         * @throws \Cloudinary\Api\GeneralError
+         * @throws Api\GeneralError
          */
         public function update_metadata_field_datasource($field_external_id, array $entries_external_id, $options = array())
         {
@@ -1486,20 +1494,20 @@ namespace Cloudinary {
         }
 
         /**
-         * Restore entries in a metadata field datasource
+         * Restores entries in a metadata field datasource
          *
          * Restores (unblocks) any previously deleted datasource entries for a specified metadata field definition.
          * Sets the state of the entries to active.
          *
          * @see https://cloudinary.com/documentation/admin_api#restore_entries_in_a_metadata_field_datasource
          *
-         * @param string $field_external_id The ID of the metadata field
-         * @param array $entries_external_ids An array of IDs of datasource entries to restore (unblock)
-         * @param array $options Additional options
+         * @param string    $field_external_id      The ID of the metadata field
+         * @param array     $entries_external_ids   An array of IDs of datasource entries to restore (unblock)
+         * @param array     $options                Additional options
          *
-         * @return \Cloudinary\Api\Response
+         * @return Api\Response
          *
-         * @throws \Cloudinary\Api\GeneralError
+         * @throws Api\GeneralError
          */
         public function restore_metadata_field_datasource($field_external_id, array $entries_external_ids, $options = array())
         {

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -405,7 +405,9 @@ class MetadataTest extends TestCase
      */
     public function test_delete_metadata_field()
     {
-        $this->api->delete_metadata_field(self::$unique_external_id_for_deletion);
+        $result = $this->api->delete_metadata_field(self::$unique_external_id_for_deletion);
+
+        $this->assertEquals('ok', $result['message']);
 
         $this->setExpectedException('\Cloudinary\Api\NotFound');
         $this->api->metadata_field_by_field_id(self::$unique_external_id_for_deletion);

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -216,10 +216,12 @@ class MetadataTest extends TestCase
     {
         $this->assertNotEmpty($dataSource);
         $this->assertArrayHasKey('values', $dataSource);
-        if (!empty($values)) {
+        if (!empty($dataSource['values'])) {
             $this->assertInternalType('string', $dataSource['values'][0]['value']);
             $this->assertInternalType('string', $dataSource['values'][0]['external_id']);
-            $this->assertContains($dataSource['values'][0]['state'], ['active', 'inactive']);
+            if (!empty($dataSource['values'][0]['state'])) {
+                $this->assertContains($dataSource['values'][0]['state'], ['active', 'inactive']);
+            }
         }
     }
 

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -164,7 +164,7 @@ class MetadataTest extends TestCase
      *
      * @throws Api\GeneralError
      */
-    private static function create_metadata_field_for_test(Api &$api, array $field)
+    private static function create_metadata_field_for_test(Api &$api, $field)
     {
         if (!isset($field['label'])) {
             $field['label'] = $field['external_id'];
@@ -183,7 +183,7 @@ class MetadataTest extends TestCase
      * @param array         $values         An associative array where the key is the name of the parameter to check and the
      *                                      value is the value
      */
-    private function assert_metadata_field(Response $metadataField, $type = null, array $values = array())
+    private function assert_metadata_field(Response $metadataField, $type = null, $values = array())
     {
         $this->assertInternalType('string', $metadataField['external_id']);
         if ($type) {

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -467,7 +467,7 @@ class MetadataTest extends TestCase
     public function test_date_field_default_value_validation()
     {
         $pastDate = date('Y-m-d', time() - 60 * 60 * 24 * 3);
-        $yesterdaydate = date('Y-m-d', time() - 60 * 60 * 24);
+        $yesterdayDate = date('Y-m-d', time() - 60 * 60 * 24);
         $todayDate = date('Y-m-d');
         $futureDate = date('Y-m-d', time() + 60 * 60 * 24 * 3);
         $lastThreeDaysValidation = [
@@ -491,7 +491,7 @@ class MetadataTest extends TestCase
             'external_id' => self::$unique_external_id_for_testing_date_validation,
             'label' => self::$unique_external_id_for_testing_date_validation,
             'type' => 'date',
-            'default_value' => $yesterdaydate,
+            'default_value' => $yesterdayDate,
             'validation' => $lastThreeDaysValidation
         ];
         $result = $this->api->add_metadata_field($metadata_field);

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -1,0 +1,559 @@
+<?php
+
+namespace Cloudinary;
+
+use Exception;
+use Cloudinary;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class MetadataTest
+ * @package Cloudinary
+ */
+class MetadataTest extends TestCase
+{
+    private static $unique_external_id_general;
+    private static $unique_external_id_string;
+    private static $unique_external_id_int;
+    private static $unique_external_id_date;
+    private static $unique_external_id_enum;
+    private static $unique_external_id_enum_2;
+    private static $unique_external_id_set;
+    private static $unique_external_id_set_2;
+    private static $unique_external_id_set_3;
+    private static $unique_external_id_for_deletion;
+    private static $unique_external_id_for_testing_date_validation;
+    private static $unique_external_id_for_testing_date_validation_2;
+    private static $unique_external_id_for_testing_integer_validation;
+    private static $unique_external_id_for_testing_integer_validation_2;
+    private static $unique_datasource_entry_external_id;
+    private static $datasource_single;
+    private static $datasource_multiple;
+
+    /**
+     * @var  \Cloudinary\Api $api
+     */
+    private $api;
+
+    public static function setUpBeforeClass()
+    {
+        if (!Cloudinary::config_get("api_secret")) {
+            self::markTestSkipped('Please setup environment for Api test to run');
+        }
+        self::$unique_external_id_general = 'metadata_external_id_general_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_string = 'metadata_external_id_string_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_int = 'metadata_external_id_int_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_date = 'metadata_external_id_date_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_enum = 'metadata_external_id_enum_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_enum_2 = 'metadata_external_id_enum_2_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_set = 'metadata_external_id_set_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_set_2 = 'metadata_external_id_set_2_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_set_3 = 'metadata_external_id_set_3_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_for_deletion = 'metadata_deletion_test_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_for_testing_date_validation = 'metadata_date_validation_test_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_for_testing_date_validation_2 = 'metadata_date_validation_test_2_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_for_testing_integer_validation = 'metadata_integer_validation_test_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_for_testing_integer_validation_2 = 'metadata_integer_validation_test_2_' . UNIQUE_TEST_ID;
+        self::$unique_datasource_entry_external_id = 'metadata_datasource_entry_external_id' . UNIQUE_TEST_ID;
+        self::$datasource_single = [
+            [
+                'value' => 'v1',
+                'external_id' => self::$unique_datasource_entry_external_id,
+            ]
+        ];
+        self::$datasource_multiple = [
+            [
+                'value' => 'v2',
+                'external_id' => self::$unique_datasource_entry_external_id,
+            ],
+            [
+                'value' => 'v3'
+            ],
+            [
+                'value' => 'v4'
+            ],
+        ];
+
+        try {
+            (new Api())->add_metadata_field([
+                'external_id' => self::$unique_external_id_general,
+                'label' => self::$unique_external_id_general,
+                'type' => 'string'
+            ]);
+            (new Api())->add_metadata_field([
+                'datasource' => [
+                    'values' => self::$datasource_multiple
+                ],
+                'external_id' => self::$unique_external_id_enum_2,
+                'label' => self::$unique_external_id_enum_2,
+                'type' => 'enum'
+            ]);
+            (new Api())->add_metadata_field([
+                'datasource' => [
+                    'values' => self::$datasource_multiple
+                ],
+                'external_id' => self::$unique_external_id_set_2,
+                'label' => self::$unique_external_id_set_2,
+                'type' => 'set'
+            ]);
+            (new Api())->add_metadata_field([
+                'datasource' => [
+                    'values' => self::$datasource_multiple
+                ],
+                'external_id' => self::$unique_external_id_set_3,
+                'label' => self::$unique_external_id_set_3,
+                'type' => 'set'
+            ]);
+            (new Api())->add_metadata_field([
+                'external_id' => self::$unique_external_id_for_deletion,
+                'label' => self::$unique_external_id_for_deletion,
+                'type' => 'integer'
+            ]);
+        } catch (Exception $e) {
+            self::fail(
+                'Exception thrown while adding metadata field in MetadataFieldsTest::setUpBeforeClass() - ' .
+                $e->getMessage()
+            );
+        }
+    }
+
+    protected function setUp()
+    {
+        $this->api = new Api();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $api = new Api();
+
+        try {
+            $api->delete_metadata_field(self::$unique_external_id_general);
+            $api->delete_metadata_field(self::$unique_external_id_string);
+            $api->delete_metadata_field(self::$unique_external_id_int);
+            $api->delete_metadata_field(self::$unique_external_id_date);
+            $api->delete_metadata_field(self::$unique_external_id_enum);
+            $api->delete_metadata_field(self::$unique_external_id_enum_2);
+            $api->delete_metadata_field(self::$unique_external_id_set);
+            $api->delete_metadata_field(self::$unique_external_id_set_2);
+            $api->delete_metadata_field(self::$unique_external_id_set_3);
+            $api->delete_metadata_field(self::$unique_external_id_for_testing_date_validation);
+            $api->delete_metadata_field(self::$unique_external_id_for_testing_integer_validation);
+        } catch (Exception $e) {
+            self::fail(
+                'Exception thrown while deleting metadata fields in MetadataFieldsTest::tearDownAfterClass() - ' .
+                $e->getMessage()
+            );
+        }
+        self::delete_extra_metadata_fields($api);
+    }
+
+    /**
+     * Delete leftover metadata fields which should have been deleted in case something broke and they were not deleted
+     *
+     * @param \Cloudinary\Api $api
+     */
+    private static function delete_extra_metadata_fields($api)
+    {
+        $externalIds = array(
+            self::$unique_external_id_for_deletion,
+            self::$unique_external_id_for_testing_date_validation_2,
+            self::$unique_external_id_for_testing_integer_validation_2,
+        );
+        foreach ($externalIds as $externalId) {
+            try {
+                $api->delete_metadata_field($externalId);
+            } catch (Exception $e) {
+            }
+        }
+    }
+
+    /**
+     * Asserts that a given object fits the generic structure of a metadata field
+     *
+     * @see https://cloudinary.com/documentation/admin_api#generic_structure_of_a_metadata_field
+     *
+     * @param \Cloudinary\Api\Response $metadataField The object to test
+     * @param string $type          The type of metadata field we expect
+     * @param array $values         An associative array where the key is the name of the parameter to check and the
+     *                              value is the value
+     */
+    private function assert_metadata_field($metadataField, $type = null, $values = array())
+    {
+        $this->assertInternalType('string', $metadataField['external_id']);
+        if ($type) {
+            $this->assertEquals($type, $metadataField['type']);
+        } else {
+            $this->assertContains($metadataField['type'], ['string', 'integer', 'date', 'enum', 'set']);
+        }
+        $this->assertInternalType('string', $metadataField['label']);
+        $this->assertInternalType('boolean', $metadataField['mandatory']);
+        $this->assertArrayHasKey('default_value', $metadataField);
+        $this->assertArrayHasKey('validation', $metadataField);
+        if (in_array($metadataField['type'], ['enum', 'set'])) {
+            $this->assert_metadata_field_datasource($metadataField['datasource']);
+        }
+
+        foreach ($values as $key => $value) {
+            $this->assertEquals($value, $metadataField[$key]);
+        }
+    }
+
+    /**
+     * Asserts that a given object fits the generic structure of a metadata field datasource
+     *
+     * @see https://cloudinary.com/documentation/admin_api#datasource_values
+     *
+     * @param $dataSource
+     */
+    private function assert_metadata_field_datasource($dataSource)
+    {
+        $this->assertNotEmpty($dataSource);
+        $this->assertArrayHasKey('values', $dataSource);
+        if (!empty($values)) {
+            $this->assertInternalType('string', $dataSource['values'][0]['value']);
+            $this->assertInternalType('string', $dataSource['values'][0]['external_id']);
+            $this->assertContains($dataSource['values'][0]['state'], ['active', 'inactive']);
+        }
+    }
+
+    /**
+     * Test getting a list of all metadata fields
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_list_metadata_fields()
+    {
+        $result = $this->api->list_metadata_fields();
+
+        $this->assertGreaterThanOrEqual(1, count($result['metadata_fields']));
+        $this->assert_metadata_field($result['metadata_fields'][0]);
+    }
+
+    /**
+     * Test getting a metadata field by external id
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_get_metadata_field()
+    {
+        $result = $this->api->metadata_field_by_field_id(self::$unique_external_id_general);
+
+        $this->assert_metadata_field($result, 'string', ['label' => self::$unique_external_id_general]);
+    }
+
+    /**
+     * Test creating a string metadata field
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_create_string_metadata_field()
+    {
+        $result = $this->api->add_metadata_field([
+            'external_id' => self::$unique_external_id_string,
+            'label' => self::$unique_external_id_string,
+            'type' => 'string'
+        ]);
+
+        $this->assert_metadata_field($result, 'string', [
+            'label' => self::$unique_external_id_string,
+            'external_id' => self::$unique_external_id_string,
+            'mandatory' => false
+        ]);
+    }
+
+    /**
+     * Test creating an integer metadata field
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_create_int_metadata_field()
+    {
+        $result = $this->api->add_metadata_field([
+            'external_id' => self::$unique_external_id_int,
+            'label' => self::$unique_external_id_int,
+            'type' => 'integer'
+        ]);
+
+        $this->assert_metadata_field($result, 'integer', [
+            'label' => self::$unique_external_id_int,
+            'external_id' => self::$unique_external_id_int,
+            'mandatory' => false
+        ]);
+    }
+
+    /**
+     * Test creating a date metadata field
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_create_date_metadata_field()
+    {
+        $result = $this->api->add_metadata_field([
+            'external_id' => self::$unique_external_id_date,
+            'label' => self::$unique_external_id_date,
+            'type' => 'date'
+        ]);
+
+        $this->assert_metadata_field($result, 'date', [
+            'label' => self::$unique_external_id_date,
+            'external_id' => self::$unique_external_id_date,
+            'mandatory' => false
+        ]);
+    }
+
+    /**
+     * Test creating an Enum metadata field
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_create_enum_metadata_field()
+    {
+        $result = $this->api->add_metadata_field([
+            'datasource' => [
+                'values' => self::$datasource_single
+            ],
+            'external_id' => self::$unique_external_id_enum,
+            'label' => self::$unique_external_id_enum,
+            'type' => 'enum'
+        ]);
+
+        $this->assert_metadata_field($result, 'enum', [
+            'label' => self::$unique_external_id_enum,
+            'external_id' => self::$unique_external_id_enum,
+            'mandatory' => false
+        ]);
+    }
+
+    /**
+     * Test creating a set metadata field
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_create_set_metadata_field()
+    {
+        $result = $this->api->add_metadata_field([
+            'datasource' => [
+                'values' => self::$datasource_multiple
+            ],
+            'external_id' => self::$unique_external_id_set,
+            'label' => self::$unique_external_id_set,
+            'type' => 'set'
+        ]);
+
+        $this->assert_metadata_field($result, 'set', [
+            'label' => self::$unique_external_id_set,
+            'external_id' => self::$unique_external_id_set,
+            'mandatory' => false
+        ]);
+    }
+
+    /**
+     * Update a metadata field by external id
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_update_metadata_field()
+    {
+        $newLabel = 'update_metadata_test_' . self::$unique_external_id_general;
+        $newDefaultValue = 'update_metadata_test_' . self::$unique_external_id_general;
+
+        // Call the API to update the metadata field
+        // Will also attempt to update some fields that cannot be updated (external_id and type) which will be ignored
+        $result = $this->api->update_metadata_field(
+            self::$unique_external_id_general,
+            [
+                'external_id' => self::$unique_external_id_set,
+                'label' => $newLabel,
+                'type' => 'integer',
+                'mandatory' => true,
+                'default_value' => $newDefaultValue
+            ]
+        );
+
+        $this->assert_metadata_field($result, 'string', [
+            'external_id' => self::$unique_external_id_general,
+            'label' => $newLabel,
+            'default_value' => $newDefaultValue,
+            'mandatory' => true,
+        ]);
+    }
+
+    /**
+     * Update a metadata field datasource
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_update_metadata_field_datasource()
+    {
+        $result = $this->api->update_metadata_field_datasource(
+            self::$unique_external_id_enum_2,
+            self::$datasource_single
+        );
+
+        $this->assert_metadata_field_datasource($result);
+        assertArrayContainsArray($this, $result['values'], self::$datasource_single[0]);
+        $this->assertCount(count(self::$datasource_multiple), $result['values']);
+        $this->assertEquals(self::$datasource_single[0]['value'], $result['values'][0]['value']);
+    }
+
+    /**
+     * Test deleting a metadata field definition by its external id.
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_delete_metadata_field()
+    {
+        $this->api->delete_metadata_field(self::$unique_external_id_for_deletion);
+
+        $this->setExpectedException('\Cloudinary\Api\NotFound');
+        $this->api->metadata_field_by_field_id(self::$unique_external_id_for_deletion);
+    }
+
+    /**
+     * Delete entries in a metadata field datasource
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_delete_metadata_field_data_source()
+    {
+        $result = $this->api->delete_datasource_entries(
+            self::$unique_external_id_set_2,
+            [
+                self::$unique_datasource_entry_external_id
+            ]
+        );
+
+        $this->assert_metadata_field_datasource($result);
+        $this->assertCount(count(self::$datasource_multiple) - 1, $result['values']);
+
+        $values = array_map(function($datasource_entity){
+            return $datasource_entity['value'];
+        }, $result['values']);
+
+        $this->assertContains(self::$datasource_multiple[1]['value'], $values);
+        $this->assertContains(self::$datasource_multiple[2]['value'], $values);
+    }
+
+    /**
+     * Test date field validation
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_date_field_default_value_validation()
+    {
+        $pastDate = date('Y-m-d', time() - 60 * 60 * 24 * 3);
+        $yesterdaydate = date('Y-m-d', time() - 60 * 60 * 24);
+        $todayDate = date('Y-m-d');
+        $futureDate = date('Y-m-d', time() + 60 * 60 * 24 * 3);
+        $lastThreeDaysValidation = [
+            'rules' => [
+                [
+                    'type' => 'greater_than',
+                    'equals' => false,
+                    'value' => $pastDate
+                ],
+                [
+                    'type' => 'less_than',
+                    'equals' => false,
+                    'value' => $todayDate
+                ],
+            ],
+            'type' => 'and'
+        ];
+
+        // Test entering a metadata field with date validation and a valid default value
+        $metadata_field = [
+            'external_id' => self::$unique_external_id_for_testing_date_validation,
+            'label' => self::$unique_external_id_for_testing_date_validation,
+            'type' => 'date',
+            'default_value' => $yesterdaydate,
+            'validation' => $lastThreeDaysValidation
+        ];
+        $result = $this->api->add_metadata_field($metadata_field);
+
+        $this->assert_metadata_field($result, 'date', [
+            'validation' => $lastThreeDaysValidation,
+            'default_value' => $metadata_field['default_value'],
+        ]);
+
+        // Test entering a metadata field with date validation and an invalid default value
+        $metadata_field = [
+            'external_id' => self::$unique_external_id_for_testing_date_validation_2,
+            'label' => self::$unique_external_id_for_testing_date_validation_2,
+            'type' => 'date',
+            'default_value' => $futureDate,
+            'validation' => $lastThreeDaysValidation
+        ];
+        $this->setExpectedException('\Cloudinary\Api\BadRequest');
+        $this->api->add_metadata_field($metadata_field);
+    }
+
+    /**
+     * Test integer field validation
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_integer_field_validation()
+    {
+        $validation = [
+            'type' => 'less_than',
+            'equals' => true,
+            'value' => 5
+        ];
+
+        // Test entering a metadata field with integer validation and a valid default value
+        $metadata_field = [
+            'external_id' => self::$unique_external_id_for_testing_integer_validation,
+            'label' => self::$unique_external_id_for_testing_integer_validation,
+            'type' => 'integer',
+            'default_value' => 5,
+            'validation' => $validation
+        ];
+        $result = $this->api->add_metadata_field($metadata_field);
+
+        $this->assert_metadata_field($result, 'integer', [
+            'validation' => $validation,
+            'default_value' => $metadata_field['default_value'],
+        ]);
+
+        // Test entering a metadata field with integer validation and a valid default value
+        $metadata_field = [
+            'external_id' => self::$unique_external_id_for_testing_integer_validation_2,
+            'label' => self::$unique_external_id_for_testing_integer_validation_2,
+            'type' => 'integer',
+            'default_value' => 6,
+            'validation' => $validation
+        ];
+        $this->setExpectedException('\Cloudinary\Api\BadRequest');
+        $this->api->add_metadata_field($metadata_field);
+    }
+
+    /**
+     * Restore a deleted entry in a metadata field datasource
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_restore_metadata_field_datasource()
+    {
+        // Begin by deleting a datasource entry
+        $result = $this->api->delete_datasource_entries(
+            self::$unique_external_id_set_3,
+            [
+                self::$unique_datasource_entry_external_id
+            ]
+        );
+
+        $this->assert_metadata_field_datasource($result);
+        $this->assertCount(2, $result['values']);
+
+        // Restore datasource entry
+        $result = $this->api->restore_metadata_field_datasource(
+            self::$unique_external_id_set_3,
+            [
+                self::$unique_datasource_entry_external_id
+            ]
+        );
+        $this->assert_metadata_field_datasource($result);
+        $this->assertCount(3, $result['values']);
+    }
+}

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MetadataTest extends TestCase
 {
+    private static $metadata_fields = [];
     private static $unique_external_id_general;
     private static $unique_external_id_string;
     private static $unique_external_id_int;
@@ -41,21 +42,21 @@ class MetadataTest extends TestCase
         if (!Cloudinary::config_get("api_secret")) {
             self::markTestSkipped('Please setup environment for Api test to run');
         }
-        self::$unique_external_id_general = 'metadata_external_id_general_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_string = 'metadata_external_id_string_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_int = 'metadata_external_id_int_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_date = 'metadata_external_id_date_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_enum = 'metadata_external_id_enum_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_enum_2 = 'metadata_external_id_enum_2_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_set = 'metadata_external_id_set_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_set_2 = 'metadata_external_id_set_2_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_set_3 = 'metadata_external_id_set_3_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_for_deletion = 'metadata_deletion_test_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_for_deletion_2 = 'metadata_deletion_test_2_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_for_testing_date_validation = 'metadata_date_validation_test_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_for_testing_date_validation_2 = 'metadata_date_validation_test_2_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_for_testing_integer_validation = 'metadata_integer_validation_test_' . UNIQUE_TEST_ID;
-        self::$unique_external_id_for_testing_integer_validation_2 = 'metadata_integer_validation_test_2_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_general = 'metadata_external_id_general_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_string = 'metadata_external_id_string_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_int = 'metadata_external_id_int_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_date = 'metadata_external_id_date_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_enum = 'metadata_external_id_enum_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_enum_2 = 'metadata_external_id_enum_2_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_set = 'metadata_external_id_set_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_set_2 = 'metadata_external_id_set_2_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_set_3 = 'metadata_external_id_set_3_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_for_deletion = 'metadata_deletion_test_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_for_deletion_2 = 'metadata_deletion_test_2_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_for_testing_date_validation = 'metadata_date_validation_test_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_for_testing_date_validation_2 = 'metadata_date_validation_test_2_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_for_testing_integer_validation = 'metadata_integer_validation_test_' . UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$unique_external_id_for_testing_integer_validation_2 = 'metadata_integer_validation_test_2_' . UNIQUE_TEST_ID;
         self::$unique_datasource_entry_external_id = 'metadata_datasource_entry_external_id' . UNIQUE_TEST_ID;
         self::$datasource_single = [
             [
@@ -133,41 +134,7 @@ class MetadataTest extends TestCase
     {
         $api = new Api();
 
-        try {
-            $api->delete_metadata_field(self::$unique_external_id_general);
-            $api->delete_metadata_field(self::$unique_external_id_string);
-            $api->delete_metadata_field(self::$unique_external_id_int);
-            $api->delete_metadata_field(self::$unique_external_id_date);
-            $api->delete_metadata_field(self::$unique_external_id_enum);
-            $api->delete_metadata_field(self::$unique_external_id_enum_2);
-            $api->delete_metadata_field(self::$unique_external_id_set);
-            $api->delete_metadata_field(self::$unique_external_id_set_2);
-            $api->delete_metadata_field(self::$unique_external_id_set_3);
-            $api->delete_metadata_field(self::$unique_external_id_for_testing_date_validation);
-            $api->delete_metadata_field(self::$unique_external_id_for_testing_integer_validation);
-        } catch (Exception $e) {
-            self::fail(
-                'Exception thrown while deleting metadata fields in MetadataFieldsTest::tearDownAfterClass() - ' .
-                $e->getMessage()
-            );
-        }
-        self::delete_extra_metadata_fields($api);
-    }
-
-    /**
-     * Delete leftover metadata fields which should have been deleted in case something broke and they were not deleted
-     *
-     * @param \Cloudinary\Api $api
-     */
-    private static function delete_extra_metadata_fields($api)
-    {
-        $externalIds = array(
-            self::$unique_external_id_for_deletion,
-            self::$unique_external_id_for_deletion_2,
-            self::$unique_external_id_for_testing_date_validation_2,
-            self::$unique_external_id_for_testing_integer_validation_2,
-        );
-        foreach ($externalIds as $externalId) {
+        foreach (self::$metadata_fields as $externalId) {
             try {
                 $api->delete_metadata_field($externalId);
             } catch (Exception $e) {

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -267,16 +267,13 @@ class MetadataTest extends TestCase
 
         assertUrl($this, '/metadata_fields');
         assertPost($this);
-        assertJson(
+        assertEncodedRequestFields(
             $this,
-            json_encode(
-                array(
-                    'type' => 'string',
-                    'external_id' => self::$external_id_string,
-                    'label' => self::$external_id_string
-                )
-            ),
-            Curl::$instance->fields(), 'Should correctly encode JSON into the HTTP request'
+            array(
+                'type' => 'string',
+                'external_id' => self::$external_id_string,
+                'label' => self::$external_id_string
+            )
         );
     }
 
@@ -297,16 +294,13 @@ class MetadataTest extends TestCase
 
         assertUrl($this, '/metadata_fields');
         assertPost($this);
-        assertJson(
+        assertEncodedRequestFields(
             $this,
-            json_encode(
-                array(
-                    'type' => 'integer',
-                    'external_id' => self::$external_id_int,
-                    'label' => self::$external_id_int
-                )
-            ),
-            Curl::$instance->fields(), 'Should correctly encode JSON into the HTTP request'
+            array(
+                'type' => 'integer',
+                'external_id' => self::$external_id_int,
+                'label' => self::$external_id_int
+            )
         );
     }
 
@@ -350,19 +344,16 @@ class MetadataTest extends TestCase
 
         assertUrl($this, '/metadata_fields');
         assertPost($this);
-        assertJson(
+        assertEncodedRequestFields(
             $this,
-            json_encode(
-                array(
-                    'datasource' => [
-                        'values' => self::$datasource_single
-                    ],
-                    'external_id' => self::$external_id_enum,
-                    'label' => self::$external_id_enum,
-                    'type' => 'enum'
-                )
-            ),
-            Curl::$instance->fields(), 'Should correctly encode JSON into the HTTP request'
+            array(
+                'datasource' => [
+                    'values' => self::$datasource_single
+                ],
+                'external_id' => self::$external_id_enum,
+                'label' => self::$external_id_enum,
+                'type' => 'enum'
+            )
         );
     }
 
@@ -456,13 +447,8 @@ class MetadataTest extends TestCase
 
         assertUrl($this, '/metadata_fields/' . self::$external_id_delete);
         assertDelete($this);
-        assertJson(
-            $this,
-            json_encode(
-                array()
-            ),
-            Curl::$instance->fields(), 'Should correctly encode JSON into the HTTP request'
-        );    }
+        assertEncodedRequestFields($this, array());
+    }
 
     /**
      * Test deleting a metadata field definition then attempting to create a new one with the same external id which

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -451,7 +451,7 @@ class MetadataTest extends TestCase
         $this->assert_metadata_field_datasource($result);
         $this->assertCount(count(self::$datasource_multiple) - 1, $result['values']);
 
-        $values = array_map(function($datasource_entity){
+        $values = array_map(function ($datasource_entity){
             return $datasource_entity['value'];
         }, $result['values']);
 

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -13,22 +13,22 @@ use PHPUnit\Framework\TestCase;
 class MetadataTest extends TestCase
 {
     private static $metadata_fields = [];
-    private static $unique_external_id_general;
-    private static $unique_external_id_string;
-    private static $unique_external_id_int;
-    private static $unique_external_id_date;
-    private static $unique_external_id_enum;
-    private static $unique_external_id_enum_2;
-    private static $unique_external_id_set;
-    private static $unique_external_id_set_2;
-    private static $unique_external_id_set_3;
-    private static $unique_external_id_for_deletion;
-    private static $unique_external_id_for_deletion_2;
-    private static $unique_external_id_for_testing_date_validation;
-    private static $unique_external_id_for_testing_date_validation_2;
-    private static $unique_external_id_for_testing_integer_validation;
-    private static $unique_external_id_for_testing_integer_validation_2;
-    private static $unique_datasource_entry_external_id;
+    private static $external_id_general;
+    private static $external_id_string;
+    private static $external_id_int;
+    private static $external_id_date;
+    private static $external_id_enum;
+    private static $external_id_enum_2;
+    private static $external_id_set;
+    private static $external_id_set_2;
+    private static $external_id_set_3;
+    private static $external_id_delete;
+    private static $external_id_delete_2;
+    private static $external_id_date_validation;
+    private static $external_id_date_validation_2;
+    private static $external_id_int_validation;
+    private static $external_id_int_validation_2;
+    private static $datasource_entry_external_id;
     private static $datasource_single;
     private static $datasource_multiple;
 
@@ -43,34 +43,33 @@ class MetadataTest extends TestCase
             self::markTestSkipped('Please setup environment for Api test to run');
         }
 
-        $api = new Api();
-
-        self::$metadata_fields[] = self::$unique_external_id_general = 'metadata_external_id_general_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_string = 'metadata_external_id_string_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_int = 'metadata_external_id_int_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_date = 'metadata_external_id_date_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_enum = 'metadata_external_id_enum_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_enum_2 = 'metadata_external_id_enum_2_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_set = 'metadata_external_id_set_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_set_2 = 'metadata_external_id_set_2_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_set_3 = 'metadata_external_id_set_3_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_for_deletion = 'metadata_deletion_test_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_for_deletion_2 = 'metadata_deletion_test_2_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_for_testing_date_validation = 'metadata_date_validation_test_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_for_testing_date_validation_2 = 'metadata_date_validation_test_2_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_for_testing_integer_validation = 'metadata_integer_validation_test_' . UNIQUE_TEST_ID;
-        self::$metadata_fields[] = self::$unique_external_id_for_testing_integer_validation_2 = 'metadata_integer_validation_test_2_' . UNIQUE_TEST_ID;
-        self::$unique_datasource_entry_external_id = 'metadata_datasource_entry_external_id' . UNIQUE_TEST_ID;
+        $id = UNIQUE_TEST_ID;
+        self::$metadata_fields[] = self::$external_id_general = 'metadata_external_id_general_' . $id;
+        self::$metadata_fields[] = self::$external_id_string = 'metadata_external_id_string_' . $id;
+        self::$metadata_fields[] = self::$external_id_int = 'metadata_external_id_int_' . $id;
+        self::$metadata_fields[] = self::$external_id_date = 'metadata_external_id_date_' . $id;
+        self::$metadata_fields[] = self::$external_id_enum = 'metadata_external_id_enum_' . $id;
+        self::$metadata_fields[] = self::$external_id_enum_2 = 'metadata_external_id_enum_2_' . $id;
+        self::$metadata_fields[] = self::$external_id_set = 'metadata_external_id_set_' . $id;
+        self::$metadata_fields[] = self::$external_id_set_2 = 'metadata_external_id_set_2_' . $id;
+        self::$metadata_fields[] = self::$external_id_set_3 = 'metadata_external_id_set_3_' . $id;
+        self::$metadata_fields[] = self::$external_id_delete = 'metadata_deletion_' . $id;
+        self::$metadata_fields[] = self::$external_id_delete_2 = 'metadata_deletion_2_' . $id;
+        self::$metadata_fields[] = self::$external_id_date_validation = 'metadata_date_validation_' . $id;
+        self::$metadata_fields[] = self::$external_id_date_validation_2 = 'metadata_date_validation_2_' . $id;
+        self::$metadata_fields[] = self::$external_id_int_validation = 'metadata_int_validation_' . $id;
+        self::$metadata_fields[] = self::$external_id_int_validation_2 = 'metadata_int_validation_2_' . $id;
+        self::$datasource_entry_external_id = 'metadata_datasource_entry_external_id' . $id;
         self::$datasource_single = [
             [
                 'value' => 'v1',
-                'external_id' => self::$unique_datasource_entry_external_id,
+                'external_id' => self::$datasource_entry_external_id,
             ]
         ];
         self::$datasource_multiple = [
             [
                 'value' => 'v2',
-                'external_id' => self::$unique_datasource_entry_external_id,
+                'external_id' => self::$datasource_entry_external_id,
             ],
             [
                 'value' => 'v3'
@@ -82,40 +81,41 @@ class MetadataTest extends TestCase
 
         $metadata_fields_to_create = [
             [
-                'external_id' => self::$unique_external_id_general,
+                'external_id' => self::$external_id_general,
                 'type' => 'string'
             ],
             [
-                'external_id' => self::$unique_external_id_enum_2,
+                'external_id' => self::$external_id_enum_2,
                 'type' => 'enum',
                 'datasource' => [
                     'values' => self::$datasource_multiple
                 ]
             ],
             [
-                'external_id' => self::$unique_external_id_set_2,
+                'external_id' => self::$external_id_set_2,
                 'type' => 'set',
                 'datasource' => [
                     'values' => self::$datasource_multiple
                 ]
             ],
             [
-                'external_id' => self::$unique_external_id_set_3,
+                'external_id' => self::$external_id_set_3,
                 'type' => 'set',
                 'datasource' => [
                     'values' => self::$datasource_multiple
                 ]
             ],
             [
-                'external_id' => self::$unique_external_id_for_deletion,
+                'external_id' => self::$external_id_delete,
                 'type' => 'integer'
             ],
             [
-                'external_id' => self::$unique_external_id_for_deletion_2,
+                'external_id' => self::$external_id_delete_2,
                 'type' => 'integer'
             ]
         ];
 
+        $api = new Api();
         try {
             foreach ($metadata_fields_to_create as $metadata_field_to_create) {
                 self::create_metadata_field_for_test($api, $metadata_field_to_create);
@@ -233,9 +233,9 @@ class MetadataTest extends TestCase
      */
     public function test_get_metadata_field()
     {
-        $result = $this->api->metadata_field_by_field_id(self::$unique_external_id_general);
+        $result = $this->api->metadata_field_by_field_id(self::$external_id_general);
 
-        $this->assert_metadata_field($result, 'string', ['label' => self::$unique_external_id_general]);
+        $this->assert_metadata_field($result, 'string', ['label' => self::$external_id_general]);
     }
 
     /**
@@ -246,14 +246,14 @@ class MetadataTest extends TestCase
     public function test_create_string_metadata_field()
     {
         $result = $this->api->add_metadata_field([
-            'external_id' => self::$unique_external_id_string,
-            'label' => self::$unique_external_id_string,
+            'external_id' => self::$external_id_string,
+            'label' => self::$external_id_string,
             'type' => 'string'
         ]);
 
         $this->assert_metadata_field($result, 'string', [
-            'label' => self::$unique_external_id_string,
-            'external_id' => self::$unique_external_id_string,
+            'label' => self::$external_id_string,
+            'external_id' => self::$external_id_string,
             'mandatory' => false
         ]);
     }
@@ -266,14 +266,14 @@ class MetadataTest extends TestCase
     public function test_create_int_metadata_field()
     {
         $result = $this->api->add_metadata_field([
-            'external_id' => self::$unique_external_id_int,
-            'label' => self::$unique_external_id_int,
+            'external_id' => self::$external_id_int,
+            'label' => self::$external_id_int,
             'type' => 'integer'
         ]);
 
         $this->assert_metadata_field($result, 'integer', [
-            'label' => self::$unique_external_id_int,
-            'external_id' => self::$unique_external_id_int,
+            'label' => self::$external_id_int,
+            'external_id' => self::$external_id_int,
             'mandatory' => false
         ]);
     }
@@ -286,14 +286,14 @@ class MetadataTest extends TestCase
     public function test_create_date_metadata_field()
     {
         $result = $this->api->add_metadata_field([
-            'external_id' => self::$unique_external_id_date,
-            'label' => self::$unique_external_id_date,
+            'external_id' => self::$external_id_date,
+            'label' => self::$external_id_date,
             'type' => 'date'
         ]);
 
         $this->assert_metadata_field($result, 'date', [
-            'label' => self::$unique_external_id_date,
-            'external_id' => self::$unique_external_id_date,
+            'label' => self::$external_id_date,
+            'external_id' => self::$external_id_date,
             'mandatory' => false
         ]);
     }
@@ -309,14 +309,14 @@ class MetadataTest extends TestCase
             'datasource' => [
                 'values' => self::$datasource_single
             ],
-            'external_id' => self::$unique_external_id_enum,
-            'label' => self::$unique_external_id_enum,
+            'external_id' => self::$external_id_enum,
+            'label' => self::$external_id_enum,
             'type' => 'enum'
         ]);
 
         $this->assert_metadata_field($result, 'enum', [
-            'label' => self::$unique_external_id_enum,
-            'external_id' => self::$unique_external_id_enum,
+            'label' => self::$external_id_enum,
+            'external_id' => self::$external_id_enum,
             'mandatory' => false
         ]);
     }
@@ -332,14 +332,14 @@ class MetadataTest extends TestCase
             'datasource' => [
                 'values' => self::$datasource_multiple
             ],
-            'external_id' => self::$unique_external_id_set,
-            'label' => self::$unique_external_id_set,
+            'external_id' => self::$external_id_set,
+            'label' => self::$external_id_set,
             'type' => 'set'
         ]);
 
         $this->assert_metadata_field($result, 'set', [
-            'label' => self::$unique_external_id_set,
-            'external_id' => self::$unique_external_id_set,
+            'label' => self::$external_id_set,
+            'external_id' => self::$external_id_set,
             'mandatory' => false
         ]);
     }
@@ -351,15 +351,15 @@ class MetadataTest extends TestCase
      */
     public function test_update_metadata_field()
     {
-        $newLabel = 'update_metadata_test_new_label' . self::$unique_external_id_general;
-        $newDefaultValue = 'update_metadata_test_new_default_value' . self::$unique_external_id_general;
+        $newLabel = 'update_metadata_test_new_label' . self::$external_id_general;
+        $newDefaultValue = 'update_metadata_test_new_default_value' . self::$external_id_general;
 
         // Call the API to update the metadata field
         // Will also attempt to update some fields that cannot be updated (external_id and type) which will be ignored
         $result = $this->api->update_metadata_field(
-            self::$unique_external_id_general,
+            self::$external_id_general,
             [
-                'external_id' => self::$unique_external_id_set,
+                'external_id' => self::$external_id_set,
                 'label' => $newLabel,
                 'type' => 'integer',
                 'mandatory' => true,
@@ -368,7 +368,7 @@ class MetadataTest extends TestCase
         );
 
         $this->assert_metadata_field($result, 'string', [
-            'external_id' => self::$unique_external_id_general,
+            'external_id' => self::$external_id_general,
             'label' => $newLabel,
             'default_value' => $newDefaultValue,
             'mandatory' => true,
@@ -383,7 +383,7 @@ class MetadataTest extends TestCase
     public function test_update_metadata_field_datasource()
     {
         $result = $this->api->update_metadata_field_datasource(
-            self::$unique_external_id_enum_2,
+            self::$external_id_enum_2,
             self::$datasource_single
         );
 
@@ -405,12 +405,12 @@ class MetadataTest extends TestCase
      */
     public function test_delete_metadata_field()
     {
-        $result = $this->api->delete_metadata_field(self::$unique_external_id_for_deletion);
+        $result = $this->api->delete_metadata_field(self::$external_id_delete);
 
         $this->assertEquals('ok', $result['message']);
 
         $this->setExpectedException('\Cloudinary\Api\NotFound');
-        $this->api->metadata_field_by_field_id(self::$unique_external_id_for_deletion);
+        $this->api->metadata_field_by_field_id(self::$external_id_delete);
     }
 
     /**
@@ -421,15 +421,15 @@ class MetadataTest extends TestCase
      */
     public function test_delete_metadata_field_does_not_release_external_id()
     {
-        $this->api->delete_metadata_field(self::$unique_external_id_for_deletion_2);
+        $this->api->delete_metadata_field(self::$external_id_delete_2);
 
         $this->setExpectedException(
             '\Cloudinary\Api\BadRequest',
-            'external id ' . self::$unique_external_id_for_deletion_2 . ' already exists'
+            'external id ' . self::$external_id_delete_2 . ' already exists'
         );
         $this->api->add_metadata_field([
-            'external_id' => self::$unique_external_id_for_deletion_2,
-            'label' => self::$unique_external_id_for_deletion_2,
+            'external_id' => self::$external_id_delete_2,
+            'label' => self::$external_id_delete_2,
             'type' => 'integer'
         ]);
     }
@@ -442,9 +442,9 @@ class MetadataTest extends TestCase
     public function test_delete_metadata_field_data_source()
     {
         $result = $this->api->delete_datasource_entries(
-            self::$unique_external_id_set_2,
+            self::$external_id_set_2,
             [
-                self::$unique_datasource_entry_external_id
+                self::$datasource_entry_external_id
             ]
         );
 
@@ -488,8 +488,8 @@ class MetadataTest extends TestCase
 
         // Test entering a metadata field with date validation and a valid default value
         $metadata_field = [
-            'external_id' => self::$unique_external_id_for_testing_date_validation,
-            'label' => self::$unique_external_id_for_testing_date_validation,
+            'external_id' => self::$external_id_date_validation,
+            'label' => self::$external_id_date_validation,
             'type' => 'date',
             'default_value' => $yesterdayDate,
             'validation' => $lastThreeDaysValidation
@@ -503,8 +503,8 @@ class MetadataTest extends TestCase
 
         // Test entering a metadata field with date validation and an invalid default value
         $metadata_field = [
-            'external_id' => self::$unique_external_id_for_testing_date_validation_2,
-            'label' => self::$unique_external_id_for_testing_date_validation_2,
+            'external_id' => self::$external_id_date_validation_2,
+            'label' => self::$external_id_date_validation_2,
             'type' => 'date',
             'default_value' => $futureDate,
             'validation' => $lastThreeDaysValidation
@@ -528,8 +528,8 @@ class MetadataTest extends TestCase
 
         // Test entering a metadata field with integer validation and a valid default value
         $metadata_field = [
-            'external_id' => self::$unique_external_id_for_testing_integer_validation,
-            'label' => self::$unique_external_id_for_testing_integer_validation,
+            'external_id' => self::$external_id_int_validation,
+            'label' => self::$external_id_int_validation,
             'type' => 'integer',
             'default_value' => 5,
             'validation' => $validation
@@ -543,8 +543,8 @@ class MetadataTest extends TestCase
 
         // Test entering a metadata field with integer validation and a valid default value
         $metadata_field = [
-            'external_id' => self::$unique_external_id_for_testing_integer_validation_2,
-            'label' => self::$unique_external_id_for_testing_integer_validation_2,
+            'external_id' => self::$external_id_int_validation_2,
+            'label' => self::$external_id_int_validation_2,
             'type' => 'integer',
             'default_value' => 6,
             'validation' => $validation
@@ -562,9 +562,9 @@ class MetadataTest extends TestCase
     {
         // Begin by deleting a datasource entry
         $result = $this->api->delete_datasource_entries(
-            self::$unique_external_id_set_3,
+            self::$external_id_set_3,
             [
-                self::$unique_datasource_entry_external_id
+                self::$datasource_entry_external_id
             ]
         );
 
@@ -573,9 +573,9 @@ class MetadataTest extends TestCase
 
         // Restore datasource entry
         $result = $this->api->restore_metadata_field_datasource(
-            self::$unique_external_id_set_3,
+            self::$external_id_set_3,
             [
-                self::$unique_datasource_entry_external_id
+                self::$datasource_entry_external_id
             ]
         );
         $this->assert_metadata_field_datasource($result);

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -351,8 +351,8 @@ class MetadataTest extends TestCase
      */
     public function test_update_metadata_field()
     {
-        $newLabel = 'update_metadata_test_' . self::$unique_external_id_general;
-        $newDefaultValue = 'update_metadata_test_' . self::$unique_external_id_general;
+        $newLabel = 'update_metadata_test_new_label' . self::$unique_external_id_general;
+        $newDefaultValue = 'update_metadata_test_new_default_value' . self::$unique_external_id_general;
 
         // Call the API to update the metadata field
         // Will also attempt to update some fields that cannot be updated (external_id and type) which will be ignored

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -22,6 +22,7 @@ class MetadataTest extends TestCase
     private static $unique_external_id_set_2;
     private static $unique_external_id_set_3;
     private static $unique_external_id_for_deletion;
+    private static $unique_external_id_for_deletion_2;
     private static $unique_external_id_for_testing_date_validation;
     private static $unique_external_id_for_testing_date_validation_2;
     private static $unique_external_id_for_testing_integer_validation;
@@ -50,6 +51,7 @@ class MetadataTest extends TestCase
         self::$unique_external_id_set_2 = 'metadata_external_id_set_2_' . UNIQUE_TEST_ID;
         self::$unique_external_id_set_3 = 'metadata_external_id_set_3_' . UNIQUE_TEST_ID;
         self::$unique_external_id_for_deletion = 'metadata_deletion_test_' . UNIQUE_TEST_ID;
+        self::$unique_external_id_for_deletion_2 = 'metadata_deletion_test_2_' . UNIQUE_TEST_ID;
         self::$unique_external_id_for_testing_date_validation = 'metadata_date_validation_test_' . UNIQUE_TEST_ID;
         self::$unique_external_id_for_testing_date_validation_2 = 'metadata_date_validation_test_2_' . UNIQUE_TEST_ID;
         self::$unique_external_id_for_testing_integer_validation = 'metadata_integer_validation_test_' . UNIQUE_TEST_ID;
@@ -109,6 +111,11 @@ class MetadataTest extends TestCase
                 'label' => self::$unique_external_id_for_deletion,
                 'type' => 'integer'
             ]);
+            (new Api())->add_metadata_field([
+                'external_id' => self::$unique_external_id_for_deletion_2,
+                'label' => self::$unique_external_id_for_deletion_2,
+                'type' => 'integer'
+            ]);
         } catch (Exception $e) {
             self::fail(
                 'Exception thrown while adding metadata field in MetadataFieldsTest::setUpBeforeClass() - ' .
@@ -156,6 +163,7 @@ class MetadataTest extends TestCase
     {
         $externalIds = array(
             self::$unique_external_id_for_deletion,
+            self::$unique_external_id_for_deletion_2,
             self::$unique_external_id_for_testing_date_validation_2,
             self::$unique_external_id_for_testing_integer_validation_2,
         );
@@ -407,6 +415,27 @@ class MetadataTest extends TestCase
 
         $this->setExpectedException('\Cloudinary\Api\NotFound');
         $this->api->metadata_field_by_field_id(self::$unique_external_id_for_deletion);
+    }
+
+    /**
+     * Test deleting a metadata field definition then attempting to create a new one with the same external id which
+     * should fail.
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    public function test_delete_metadata_field_does_not_release_external_id()
+    {
+        $this->api->delete_metadata_field(self::$unique_external_id_for_deletion_2);
+
+        $this->setExpectedException(
+            '\Cloudinary\Api\BadRequest',
+            'external id ' . self::$unique_external_id_for_deletion_2 . ' already exists'
+        );
+        $this->api->add_metadata_field([
+            'external_id' => self::$unique_external_id_for_deletion_2,
+            'label' => self::$unique_external_id_for_deletion_2,
+            'type' => 'integer'
+        ]);
     }
 
     /**

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -388,7 +388,12 @@ class MetadataTest extends TestCase
         );
 
         $this->assert_metadata_field_datasource($result);
-        assertArrayContainsArray($this, $result['values'], self::$datasource_single[0]);
+        assertArrayContainsArray(
+            $this,
+            $result['values'],
+            self::$datasource_single[0],
+            'The updated metadata field does not contain the updated datasource'
+        );
         $this->assertCount(count(self::$datasource_multiple), $result['values']);
         $this->assertEquals(self::$datasource_single[0]['value'], $result['values'][0]['value']);
     }

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -2,8 +2,9 @@
 
 namespace Cloudinary;
 
-use Exception;
 use Cloudinary;
+use Cloudinary\Api\Response;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -159,11 +160,11 @@ class MetadataTest extends TestCase
      * @param Api   $api    An instance of the Admin API
      * @param array $field  The field to add
      *
-     * @return Api\Response
+     * @return Response
      *
      * @throws Api\GeneralError
      */
-    private static function create_metadata_field_for_test(&$api, $field)
+    private static function create_metadata_field_for_test(Api &$api, array $field)
     {
         if (!isset($field['label'])) {
             $field['label'] = $field['external_id'];
@@ -177,12 +178,12 @@ class MetadataTest extends TestCase
      *
      * @see https://cloudinary.com/documentation/admin_api#generic_structure_of_a_metadata_field
      *
-     * @param Api\Response  $metadataField  The object to test
+     * @param Response      $metadataField  The object to test
      * @param string        $type           The type of metadata field we expect
      * @param array         $values         An associative array where the key is the name of the parameter to check and the
      *                                      value is the value
      */
-    private function assert_metadata_field($metadataField, $type = null, $values = array())
+    private function assert_metadata_field(Response $metadataField, $type = null, array $values = array())
     {
         $this->assertInternalType('string', $metadataField['external_id']);
         if ($type) {

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -177,12 +177,12 @@ class MetadataTest extends TestCase
     /**
      * Asserts that a given object fits the generic structure of a metadata field
      *
-     * @see https://cloudinary.com/documentation/admin_api#generic_structure_of_a_metadata_field
+     * @see https://cloudinary.com/documentation/admin_api#generic_structure_of_a_metadata_field Generic structure of a metadata field in API reference
      *
-     * @param Response $metadataField       The object to test
-     * @param string   $type                The type of metadata field we expect
-     * @param array    $values              An associative array where the key is the name of the parameter to check
-     *                                      and the value is the value
+     * @param Response $metadataField The object to test
+     * @param string   $type          The type of metadata field we expect
+     * @param array    $values        An associative array where the key is the name of the parameter to check and the
+     *                                value is the value
      */
     private function assert_metadata_field(Response $metadataField, $type = null, $values = array())
     {
@@ -208,7 +208,7 @@ class MetadataTest extends TestCase
     /**
      * Asserts that a given object fits the generic structure of a metadata field datasource
      *
-     * @see https://cloudinary.com/documentation/admin_api#datasource_values
+     * @see https://cloudinary.com/documentation/admin_api#datasource_values Datasource values in Admin API
      *
      * @param $dataSource
      */

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -33,7 +33,7 @@ class MetadataTest extends TestCase
     private static $datasource_multiple;
 
     /**
-     * @var  \Cloudinary\Api $api
+     * @var Api $api
      */
     private $api;
 
@@ -156,12 +156,12 @@ class MetadataTest extends TestCase
     /**
      * Private helper method to create metadata fields for this test
      *
-     * @param Api $api an instance of the Admin API
-     * @param array $field The field to add
+     * @param Api   $api    An instance of the Admin API
+     * @param array $field  The field to add
      *
-     * @return \Cloudinary\Api\Response
+     * @return Api\Response
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     private static function create_metadata_field_for_test(&$api, $field)
     {
@@ -177,10 +177,10 @@ class MetadataTest extends TestCase
      *
      * @see https://cloudinary.com/documentation/admin_api#generic_structure_of_a_metadata_field
      *
-     * @param \Cloudinary\Api\Response $metadataField The object to test
-     * @param string $type          The type of metadata field we expect
-     * @param array $values         An associative array where the key is the name of the parameter to check and the
-     *                              value is the value
+     * @param Api\Response  $metadataField  The object to test
+     * @param string        $type           The type of metadata field we expect
+     * @param array         $values         An associative array where the key is the name of the parameter to check and the
+     *                                      value is the value
      */
     private function assert_metadata_field($metadataField, $type = null, $values = array())
     {
@@ -224,7 +224,7 @@ class MetadataTest extends TestCase
     /**
      * Test getting a list of all metadata fields
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_list_metadata_fields()
     {
@@ -240,7 +240,7 @@ class MetadataTest extends TestCase
     /**
      * Test getting a metadata field by external id
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_get_metadata_field()
     {
@@ -252,7 +252,7 @@ class MetadataTest extends TestCase
     /**
      * Test creating a string metadata field
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_create_string_metadata_field()
     {
@@ -282,7 +282,7 @@ class MetadataTest extends TestCase
     /**
      * Test creating an integer metadata field
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_create_int_metadata_field()
     {
@@ -312,7 +312,7 @@ class MetadataTest extends TestCase
     /**
      * Test creating a date metadata field
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_create_date_metadata_field()
     {
@@ -332,7 +332,7 @@ class MetadataTest extends TestCase
     /**
      * Test creating an Enum metadata field
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_create_enum_metadata_field()
     {
@@ -368,7 +368,7 @@ class MetadataTest extends TestCase
     /**
      * Test creating a set metadata field
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_create_set_metadata_field()
     {
@@ -391,7 +391,7 @@ class MetadataTest extends TestCase
     /**
      * Update a metadata field by external id
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_update_metadata_field()
     {
@@ -422,7 +422,7 @@ class MetadataTest extends TestCase
     /**
      * Update a metadata field datasource
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_update_metadata_field_datasource()
     {
@@ -445,7 +445,7 @@ class MetadataTest extends TestCase
     /**
      * Test deleting a metadata field definition by its external id.
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_delete_metadata_field()
     {
@@ -467,7 +467,7 @@ class MetadataTest extends TestCase
      * Test deleting a metadata field definition then attempting to create a new one with the same external id which
      * should fail.
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_delete_metadata_field_does_not_release_external_id()
     {
@@ -487,7 +487,7 @@ class MetadataTest extends TestCase
     /**
      * Delete entries in a metadata field datasource
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_delete_metadata_field_data_source()
     {
@@ -512,7 +512,7 @@ class MetadataTest extends TestCase
     /**
      * Test date field validation
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_date_field_default_value_validation()
     {
@@ -566,7 +566,7 @@ class MetadataTest extends TestCase
     /**
      * Test integer field validation
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_integer_field_validation()
     {
@@ -606,7 +606,7 @@ class MetadataTest extends TestCase
     /**
      * Restore a deleted entry in a metadata field datasource
      *
-     * @throws \Cloudinary\Api\GeneralError
+     * @throws Api\GeneralError
      */
     public function test_restore_metadata_field_datasource()
     {

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -42,6 +42,9 @@ class MetadataTest extends TestCase
         if (!Cloudinary::config_get("api_secret")) {
             self::markTestSkipped('Please setup environment for Api test to run');
         }
+
+        $api = new Api();
+
         self::$metadata_fields[] = self::$unique_external_id_general = 'metadata_external_id_general_' . UNIQUE_TEST_ID;
         self::$metadata_fields[] = self::$unique_external_id_string = 'metadata_external_id_string_' . UNIQUE_TEST_ID;
         self::$metadata_fields[] = self::$unique_external_id_int = 'metadata_external_id_int_' . UNIQUE_TEST_ID;
@@ -77,46 +80,46 @@ class MetadataTest extends TestCase
             ],
         ];
 
-        try {
-            (new Api())->add_metadata_field([
+        $metadata_fields_to_create = [
+            [
                 'external_id' => self::$unique_external_id_general,
-                'label' => self::$unique_external_id_general,
                 'type' => 'string'
-            ]);
-            (new Api())->add_metadata_field([
-                'datasource' => [
-                    'values' => self::$datasource_multiple
-                ],
+            ],
+            [
                 'external_id' => self::$unique_external_id_enum_2,
-                'label' => self::$unique_external_id_enum_2,
-                'type' => 'enum'
-            ]);
-            (new Api())->add_metadata_field([
+                'type' => 'enum',
                 'datasource' => [
                     'values' => self::$datasource_multiple
-                ],
+                ]
+            ],
+            [
                 'external_id' => self::$unique_external_id_set_2,
-                'label' => self::$unique_external_id_set_2,
-                'type' => 'set'
-            ]);
-            (new Api())->add_metadata_field([
+                'type' => 'set',
                 'datasource' => [
                     'values' => self::$datasource_multiple
-                ],
+                ]
+            ],
+            [
                 'external_id' => self::$unique_external_id_set_3,
-                'label' => self::$unique_external_id_set_3,
-                'type' => 'set'
-            ]);
-            (new Api())->add_metadata_field([
+                'type' => 'set',
+                'datasource' => [
+                    'values' => self::$datasource_multiple
+                ]
+            ],
+            [
                 'external_id' => self::$unique_external_id_for_deletion,
-                'label' => self::$unique_external_id_for_deletion,
                 'type' => 'integer'
-            ]);
-            (new Api())->add_metadata_field([
+            ],
+            [
                 'external_id' => self::$unique_external_id_for_deletion_2,
-                'label' => self::$unique_external_id_for_deletion_2,
                 'type' => 'integer'
-            ]);
+            ]
+        ];
+
+        try {
+            foreach ($metadata_fields_to_create as $metadata_field_to_create) {
+                self::create_metadata_field_for_test($api, $metadata_field_to_create);
+            }
         } catch (Exception $e) {
             self::fail(
                 'Exception thrown while adding metadata field in MetadataFieldsTest::setUpBeforeClass() - ' .
@@ -140,6 +143,25 @@ class MetadataTest extends TestCase
             } catch (Exception $e) {
             }
         }
+    }
+
+    /**
+     * Private helper method to create metadata fields for this test
+     *
+     * @param Api $api an instance of the Admin API
+     * @param array $field The field to add
+     *
+     * @return \Cloudinary\Api\Response
+     *
+     * @throws \Cloudinary\Api\GeneralError
+     */
+    private static function create_metadata_field_for_test(&$api, $field)
+    {
+        if (!isset($field['label'])) {
+            $field['label'] = $field['external_id'];
+        }
+
+        return $api->add_metadata_field($field);
     }
 
     /**

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class MetadataTest
+ *
  * @package Cloudinary
  */
 class MetadataTest extends TestCase
@@ -157,8 +158,8 @@ class MetadataTest extends TestCase
     /**
      * Private helper method to create metadata fields for this test
      *
-     * @param Api   $api    An instance of the Admin API
-     * @param array $field  The field to add
+     * @param Api   $api   An instance of the Admin API
+     * @param array $field The field to add
      *
      * @return Response
      *
@@ -178,10 +179,10 @@ class MetadataTest extends TestCase
      *
      * @see https://cloudinary.com/documentation/admin_api#generic_structure_of_a_metadata_field
      *
-     * @param Response      $metadataField  The object to test
-     * @param string        $type           The type of metadata field we expect
-     * @param array         $values         An associative array where the key is the name of the parameter to check and the
-     *                                      value is the value
+     * @param Response $metadataField       The object to test
+     * @param string   $type                The type of metadata field we expect
+     * @param array    $values              An associative array where the key is the name of the parameter to check
+     *                                      and the value is the value
      */
     private function assert_metadata_field(Response $metadataField, $type = null, $values = array())
     {
@@ -488,7 +489,7 @@ class MetadataTest extends TestCase
         $this->assert_metadata_field_datasource($result);
         $this->assertCount(count(self::$datasource_multiple) - 1, $result['values']);
 
-        $values = array_map(function ($datasource_entity){
+        $values = array_map(function ($datasource_entity) {
             return $datasource_entity['value'];
         }, $result['values']);
 

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -146,22 +146,19 @@ namespace Cloudinary {
                 ->with_field("image_metadata")
                 ->execute();
 
-            assertJson(
+            assertEncodedRequestFields(
                 $this,
-                json_encode(
-                    array(
-                        "sort_by" => array(
-                            array("created_at" => "asc"),
-                            array("updated_at" => "desc"),
-                        ),
+                array(
+                    "sort_by" => array(
+                        array("created_at" => "asc"),
+                        array("updated_at" => "desc"),
+                    ),
                     "aggregate" => array("format", "resource_type"),
                     "with_field" => array("tags", "image_metadata"),
                     "expression" => "format:jpg",
                     "max_results" => 10,
-                    "next_cursor" => "abcd",
-                    )
-                ),
-                Curl::$instance->fields(), "Should correctly encode JSON into the HTTP request"
+                    "next_cursor" => "abcd"
+                )
             );
 
             assertJson(

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -288,7 +288,7 @@ END;
     }
 
     /**
-     * Assert that fields is correctly encoded into the HTTP request
+     * Asserts that request fields are correctly encoded into the HTTP request
      *
      * @param TestCase  $test
      * @param array     $fields

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -2,6 +2,7 @@
 
 namespace Cloudinary {
 
+    use PHPUnit\Framework\TestCase;
     const RAW_FILE = "tests/docx.docx";
     const TEST_IMG = "tests/logo.png";
     const TEST_ICO = "tests/favicon.ico";
@@ -271,17 +272,19 @@ END;
     /**
      * Reports an error if the $haystack array does not contain the $needle array.
      *
-     * @param $test
+     * @param TestCase $test
      * @param array $haystack
      * @param array $needle
+     * @param string $message
      */
-    function assertArrayContainsArray($test, $haystack, $needle)
+    function assertArrayContainsArray($test, $haystack, $needle, $message = '')
     {
+        $message = empty($message) ? 'The $haystack array does not contain the $needle array' : $message;
         $result = array_filter($haystack, function ($item) use ($needle) {
             return $item == $needle;
         });
 
-        $test->assertGreaterThanOrEqual(1, count($result), 'The $haystack array does not contain the $needle array');
+        $test->assertGreaterThanOrEqual(1, count($result), $message);
     }
 
 }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -287,4 +287,20 @@ END;
         $test->assertGreaterThanOrEqual(1, count($result), $message);
     }
 
+    /**
+     * Assert that fields is correctly encoded into the HTTP request
+     *
+     * @param TestCase  $test
+     * @param array     $fields
+     * @param string    $message
+     */
+    function assertEncodedRequestFields(TestCase $test, array $fields = array(), $message = '')
+    {
+        assertJson(
+            $test,
+            json_encode($fields),
+            Curl::$instance->fields(),
+            empty($message) ? 'Should correctly encode JSON into the HTTP request' : $message
+        );
+    }
 }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -294,7 +294,7 @@ END;
      * @param array     $fields
      * @param string    $message
      */
-    function assertEncodedRequestFields(TestCase $test, array $fields = array(), $message = '')
+    function assertEncodedRequestFields(TestCase $test, $fields = array(), $message = '')
     {
         assertJson(
             $test,

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -290,9 +290,9 @@ END;
     /**
      * Asserts that request fields are correctly encoded into the HTTP request
      *
-     * @param TestCase  $test
-     * @param array     $fields
-     * @param string    $message
+     * @param TestCase $test
+     * @param array    $fields
+     * @param string   $message
      */
     function assertEncodedRequestFields(TestCase $test, $fields = array(), $message = '')
     {

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -267,4 +267,21 @@ END;
         }
         $test->assertContains(strtolower($header), $names, $message);
     }
+
+    /**
+     * Reports an error if the $haystack array does not contain the $needle array.
+     *
+     * @param $test
+     * @param array $haystack
+     * @param array $needle
+     */
+    function assertArrayContainsArray($test, $haystack, $needle)
+    {
+        $result = array_filter($haystack, function ($item) use ($needle) {
+            return $item == $needle;
+        });
+
+        $test->assertGreaterThanOrEqual(1, count($result), 'The $haystack array does not contain the $needle array');
+    }
+
 }

--- a/tests/UploaderTest.php
+++ b/tests/UploaderTest.php
@@ -93,7 +93,7 @@ namespace Cloudinary {
         }
 
         /**
-         * @throws \Cloudinary\Api\GeneralError
+         * @throws GeneralError
          */
         public static function tearDownAfterClass()
         {
@@ -929,7 +929,7 @@ TAG
         /**
          * Editing metadata of an existing resource
          *
-         * @throws \Cloudinary\Error
+         * @throws Error
          */
         public function test_uploader_update_metadata()
         {
@@ -944,7 +944,7 @@ TAG
         /**
          * Editing metadata of multiple existing resources
          *
-         * @throws \Cloudinary\Error
+         * @throws Error
          */
         public function test_uploader_update_metadata_on_multiple_resources()
         {

--- a/tests/UploaderTest.php
+++ b/tests/UploaderTest.php
@@ -3,6 +3,8 @@
 namespace Cloudinary {
 
     use Cloudinary;
+    use Cloudinary\Api\GeneralError;
+    use Cloudinary\Api\NotFound;
     use Cloudinary\Cache\Adapter\KeyValueCacheAdapter;
     use Cloudinary\Cache\ResponsiveBreakpointsCache;
     use Cloudinary\Test\Cache\Storage\DummyCacheStorage;
@@ -23,8 +25,33 @@ namespace Cloudinary {
         protected static $rbp_values = [206, 50];
         protected static $rbp_params;
 
+        private static $metadata_field_unique_external_id;
+        private static $metadata_field_value;
+        private static $metadata_fields;
+
         public static function setUpBeforeClass()
         {
+            Cloudinary::reset_config();
+
+            self::$metadata_field_unique_external_id = 'metadata_field_external_id_' . UNIQUE_TEST_ID;
+            self::$metadata_field_value = 'metadata_field_value_' . UNIQUE_TEST_ID;
+            self::$metadata_fields = [
+                self::$metadata_field_unique_external_id => self::$metadata_field_value
+            ];
+
+            try {
+                (new Cloudinary\Api())->add_metadata_field([
+                    'external_id' => self::$metadata_field_unique_external_id,
+                    'label' => self::$metadata_field_unique_external_id,
+                    'type' => 'string'
+                ]);
+            } catch (GeneralError $e) {
+                self::fail(
+                    'Exception thrown while adding metadata field in UploaderTest::setUpBeforeClass() - ' .
+                    $e->getMessage()
+                );
+            }
+
             Curl::$instance = new Curl();
 
             self::$rbp_params = [
@@ -65,6 +92,9 @@ namespace Cloudinary {
             Curl::$instance = new Curl();
         }
 
+        /**
+         * @throws \Cloudinary\Api\GeneralError
+         */
         public static function tearDownAfterClass()
         {
             if (!Cloudinary::config_get("api_secret")) {
@@ -72,6 +102,12 @@ namespace Cloudinary {
             }
 
             $api = new Cloudinary\Api();
+
+            try {
+                $api->delete_metadata_field(self::$metadata_field_unique_external_id);
+            } catch (NotFound $e) {
+                printf("The metadata field '%s' could not be deleted.\n", self::$metadata_field_unique_external_id);
+            }
 
             self::delete_resources($api);
         }
@@ -855,6 +891,79 @@ TAG
             }
 
             $this->assertEquals(2, count($response["image_infos"]));
+        }
+
+        /**
+         * Upload should supported `metadata` parameter
+         */
+        public function test_upload_with_metadata()
+        {
+            $result = Uploader::upload(
+                TEST_IMG,
+                [
+                    'tags' => array(TEST_TAG, UNIQUE_TEST_TAG),
+                    'metadata' => self::$metadata_fields
+                ]
+            );
+            $this->assertEquals(self::$metadata_field_value, $result['metadata'][self::$metadata_field_unique_external_id]);
+        }
+
+        /**
+         * Explicit should supported `metadata` parameter
+         */
+        public function test_explicit_with_metadata()
+        {
+            $resource = Uploader::upload(TEST_IMG, [
+                "tags" => [TEST_TAG, UNIQUE_TEST_TAG],
+            ]);
+            $result = Uploader::explicit(
+                $resource['public_id'],
+                [
+                    'type' => 'upload',
+                    'metadata' => self::$metadata_fields
+                ]
+            );
+            $this->assertEquals(self::$metadata_field_value, $result['metadata'][self::$metadata_field_unique_external_id]);
+        }
+
+        /**
+         * Editing metadata of an existing resource
+         *
+         * @throws \Cloudinary\Error
+         */
+        public function test_uploader_update_metadata()
+        {
+            $resource = Uploader::upload(TEST_IMG, [
+                'tags' => [TEST_TAG, UNIQUE_TEST_TAG]
+            ]);
+            $result = Uploader::update_metadata(self::$metadata_fields, $resource['public_id']);
+            $this->assertCount(1, $result['public_ids']);
+            $this->assertContains($resource['public_id'], $result['public_ids']);
+        }
+
+        /**
+         * Editing metadata of multiple existing resources
+         *
+         * @throws \Cloudinary\Error
+         */
+        public function test_uploader_update_metadata_on_multiple_resources()
+        {
+            $resource1 = Uploader::upload(TEST_IMG, [
+                'tags' => [TEST_TAG, UNIQUE_TEST_TAG]
+            ]);
+            $resource2 = Uploader::upload(TEST_IMG, [
+                'tags' => [TEST_TAG, UNIQUE_TEST_TAG]
+            ]);
+            $result = Uploader::update_metadata(
+                self::$metadata_fields,
+                [
+                    $resource1['public_id'],
+                    $resource2['public_id']
+                ]
+            );
+            $this->assertCount(2, $result['public_ids']);
+            $this->assertContains($resource1['public_id'], $result['public_ids']);
+            $this->assertContains($resource2['public_id'], $result['public_ids']);
         }
     }
 }


### PR DESCRIPTION
* Added testing of structured metadata usage in Upload API
* Added structured metadata to Admin API
  - `list_metadata_fields()`
  - `metadata_field_by_field_id()`
  - `add_metadata_field()`
  - `update_metadata_field()`
  - `delete_metadata_field()`
  - `delete_datasource_entries()`
  - `update_metadata_field_datasource()`
  - `restore_metadata_field_datasource()`
