### PR TITLE
Fix legacy autoloader on Linux

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -32,6 +32,7 @@ function cloudinary_autoloader($class_name)
     if (substr($class_file, 0, strlen($ns_prefix)) == $ns_prefix) {
         $class_file = substr($class_file, strlen($ns_prefix));
     }
+    $class_file = str_replace('\\', DIRECTORY_SEPARATOR, $class_file);
 
     require_once $classes_dir . $class_file;
 


### PR DESCRIPTION
The legacy autoloader is assume Windows-style paths work.

This is not working for me on Linux.

The uploader code seems fine, because it is not apparently having to instantiate anything in a subnamespace. I got this error when using the search endpoint for the first time.

Presumably no one has seen this major issue as an original dev is on Windows (or Mac), search is a more obscure endpoint, and people are using the Composer autoloader.