### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -85,7 +85,7 @@ namespace Cloudinary {
             self::$streaming_profile_2 = self::$api_test . "_streaming_profile_2";
         }
 
-        public function tearDown()
+        protected function tearDown()
         {
             Curl::$instance = new Curl();
         }

--- a/tests/ArchiveTest.php
+++ b/tests/ArchiveTest.php
@@ -16,7 +16,7 @@ namespace Cloudinary {
             Curl::$instance = new Curl();
         }
 
-        public function setUp()
+        protected function setUp()
         {
             $this->tag = "archive_test_" . SUFFIX;
             $this->tags = array($this->tag, TEST_TAG, UNIQUE_TEST_TAG);
@@ -29,7 +29,7 @@ namespace Cloudinary {
             Uploader::upload("tests/logo.png", array("tags" => $this->tags, "width" => 10, "crop" => "scale"));
         }
 
-        public function tearDown()
+        protected function tearDown()
         {
             Curl::$instance = new Curl();
             $api = new \Cloudinary\Api();

--- a/tests/Cache/Adapter/KeyValueCacheAdapterTest.php
+++ b/tests/Cache/Adapter/KeyValueCacheAdapterTest.php
@@ -24,7 +24,7 @@ class KeyValueCacheAdapterTest extends TestCase
     private $value2 = [101, 201, 301, 398];
 
 
-    public function setUp()
+    protected function setUp()
     {
         $this->storage = new DummyCacheStorage();
         $this->adapter = new KeyValueCacheAdapter($this->storage);

--- a/tests/Cache/ResponsiveBreakpointsCacheTest.php
+++ b/tests/Cache/ResponsiveBreakpointsCacheTest.php
@@ -28,7 +28,7 @@ class ResponsiveBreakpointsCacheTest extends TestCase
         Curl::$instance = new Curl();
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->cache = ResponsiveBreakpointsCache::instance();
         $this->cache->setCacheAdapter(new KeyValueCacheAdapter(new DummyCacheStorage()));

--- a/tests/Cache/Storage/FileSystemKeyValueStorageTest.php
+++ b/tests/Cache/Storage/FileSystemKeyValueStorageTest.php
@@ -26,7 +26,7 @@ class FileSystemKeyValueStorageTest extends TestCase
     private $key2 = "test_key_2";
     private $value2= "test_value_2";
 
-    public function setUp()
+    protected function setUp()
     {
         $this->rootPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid(UNIQUE_TEST_ID . '_');
         mkdir($this->rootPath);
@@ -34,7 +34,7 @@ class FileSystemKeyValueStorageTest extends TestCase
         $this->storage = new FileSystemKeyValueStorage($this->rootPath);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         self::rmTree($this->rootPath);
     }

--- a/tests/CloudinaryFieldTest.php
+++ b/tests/CloudinaryFieldTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CloudinaryFieldTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         Cloudinary::config(array(
             "cloud_name" => "test123",

--- a/tests/CloudinaryTest.php
+++ b/tests/CloudinaryTest.php
@@ -48,7 +48,7 @@ class CloudinaryTest extends TestCase
 
     private $original_user_platform;
 
-    public function setUp()
+    protected function setUp()
     {
         Cloudinary::reset_config();
         Cloudinary::config(
@@ -65,7 +65,7 @@ class CloudinaryTest extends TestCase
         $this->original_user_platform = \Cloudinary::$USER_PLATFORM;
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::TearDown();
         \Cloudinary::$USER_PLATFORM = $this->original_user_platform;

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -48,7 +48,7 @@ class HelpersTest extends TestCase
         }
     }
 
-    public function setUp()
+    protected function setUp()
     {
         Curl::$instance = new Curl();
     }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -45,7 +45,7 @@ class HttpClientTest extends TestCase
         }
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->httpClient = new HttpClient();
     }

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -136,7 +136,7 @@ class MetadataTest extends TestCase
         $this->api = new Api();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Curl::$instance = new Curl();
     }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -40,7 +40,7 @@ namespace Cloudinary {
             sleep(3);
         }
 
-        public function setUp()
+        protected function setUp()
         {
             \Cloudinary::reset_config();
             if (!\Cloudinary::config_get("api_secret")) {
@@ -49,7 +49,7 @@ namespace Cloudinary {
             $this->search = new Search();
         }
 
-        public function tearDown()
+        protected function tearDown()
         {
             Curl::$instance = new Curl();
         }

--- a/tests/SignatureVerifierTest.php
+++ b/tests/SignatureVerifierTest.php
@@ -38,7 +38,7 @@ class SignatureVerifierTest extends TestCase
         self::$mockedNow = null;
     }
 
-    public function setUp()
+    protected function setUp()
     {
         \Cloudinary::reset_config();
 
@@ -47,7 +47,7 @@ class SignatureVerifierTest extends TestCase
         \Cloudinary::config(['api_secret' => self::API_SECRET]);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         \Cloudinary::reset_config();
     }

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -56,7 +56,7 @@ class TagTest extends TestCase
         Curl::$instance = new Curl();
     }
 
-    public function setUp()
+    protected function setUp()
     {
         Cloudinary::reset_config();
         Cloudinary::config(

--- a/tests/UploaderTest.php
+++ b/tests/UploaderTest.php
@@ -81,7 +81,7 @@ namespace Cloudinary {
             ];
         }
 
-        public function setUp()
+        protected function setUp()
         {
             \Cloudinary::reset_config();
             if (!Cloudinary::config_get("api_secret")) {
@@ -90,7 +90,7 @@ namespace Cloudinary {
             $this->url_prefix = Cloudinary::config_get("upload_prefix", "https://api.cloudinary.com");
         }
 
-        public function tearDown()
+        protected function tearDown()
         {
             Curl::$instance = new Curl();
         }


### PR DESCRIPTION
### Brief Summary of Changes
According to the [PHPUnit doc](https://phpunit.de/manual/4.8/en/fixtures.html#fixtures.more-setup-than-teardown), the PHPUnit fixtures are `protected function setUp` and `protected function tearDown` methods.

#### What does this PR address?
- [X] Improvements for PHPUnit fixtures

#### Are tests included?
- [X] Yes
- [ ] No

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all of the tests pass.
