### PR TITLE
Change test for `eval` upload parameter

### DIFF
--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -10,7 +10,7 @@ namespace Cloudinary {
     const TEST_ICO = "tests/favicon.ico";
     const TEST_PRESET_NAME = 'test_preset';
     define("SUFFIX", getenv("TRAVIS_JOB_ID") ?: rand(11111, 99999));
-    define('TEST_EVAL_STR', 'if (resource_info["width"] < 450) { upload_options["tags"] = "a,b" }; ' .
+    define('TEST_EVAL_STR', 'if (resource_info["width"] < 450) { upload_options["quality_analysis"] = true }; ' .
         'upload_options["context"] = "width=" + resource_info["width"]');
     define('TEST_TAG', 'cloudinary_php');
     define('UNIQUE_TEST_TAG', TEST_TAG . "_" . SUFFIX);

--- a/tests/UploaderTest.php
+++ b/tests/UploaderTest.php
@@ -12,6 +12,7 @@ namespace Cloudinary {
     use Cloudinary\Test\Cache\Storage\DummyCacheStorage;
     use Exception;
     use PHPUnit\Framework\TestCase;
+    use PHPUnit_Framework_Constraint_IsType as IsType;
 
     /**
      * Class UploaderTest
@@ -26,7 +27,6 @@ namespace Cloudinary {
         protected static $rbp_format = "png";
         protected static $rbp_values = [206, 50];
         protected static $rbp_params;
-        protected static $test_eval_tags_result = ['a', 'b'];
 
         private static $metadata_field_unique_external_id;
         private static $metadata_field_value;
@@ -988,10 +988,11 @@ TAG
          */
         public function test_eval_upload_parameter()
         {
-            $result = Uploader::upload(TEST_IMG, ['eval' => TEST_EVAL_STR]);
+            $result = Uploader::upload(TEST_IMG, ['eval' => TEST_EVAL_STR, 'tags' => [TEST_TAG, UNIQUE_TEST_TAG]]);
 
-            $this->assertEquals(self::$test_eval_tags_result, $result['tags']);
             $this->assertEquals(TEST_IMG_WIDTH, $result['context']['custom']['width']);
+            $this->assertInternalType(IsType::TYPE_ARRAY, $result['quality_analysis']);
+            $this->assertInternalType(IsType::TYPE_NUMERIC, $result['quality_analysis']['focus']);
         }
     }
 }


### PR DESCRIPTION
The test for `eval` has a bug that causes it to leave leftover images that aren't deleted during test teardown.

This happens because the current eval test overwrites the tags of the uploaded image, including the tag used in the teardown to delete it.

This PR changes the eval string to test how it does something other than changing tags.