### PR TITLE
Added helper function to ensure add on tests do not run by default

### DIFF
--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -103,4 +103,43 @@ class HelpersTest extends TestCase
         $this->assertTrue(is_array($actual_breakpoints));
         $this->assertGreaterThan(0, count($actual_breakpoints));
     }
+
+    /**
+     * Should return a true for addons that need to be tested or false otherwise.
+     */
+    public function test_should_test_add_on()
+    {
+        $cld_test_addons = getenv('CLD_TEST_ADDONS');
+
+        putenv('CLD_TEST_ADDONS');
+
+        $this->assertFalse(AddOn::should_test_add_on(AddOn::WEBPURIFY));
+
+        putenv('CLD_TEST_ADDONS=all');
+
+        $this->assertTrue(AddOn::should_test_add_on(AddOn::WEBPURIFY));
+        $this->assertTrue(AddOn::should_test_add_on(AddOn::JPEGMINI));
+
+        putenv('CLD_TEST_ADDONS=webpurify');
+
+        $this->assertTrue(AddOn::should_test_add_on(AddOn::WEBPURIFY));
+
+        putenv('CLD_TEST_ADDONS=webpurify,aspose');
+
+        $this->assertTrue(AddOn::should_test_add_on(AddOn::WEBPURIFY));
+        $this->assertTrue(AddOn::should_test_add_on(AddOn::ASPOSE));
+        $this->assertFalse(AddOn::should_test_add_on(AddOn::AZURE));
+
+        putenv('CLD_TEST_ADDONS=WeBPuRiFY,aSPoSe');
+
+        $this->assertTrue(AddOn::should_test_add_on(AddOn::WEBPURIFY));
+        $this->assertTrue(AddOn::should_test_add_on(AddOn::ASPOSE));
+        $this->assertFalse(AddOn::should_test_add_on(AddOn::AZURE));
+
+        if ($cld_test_addons !== false) {
+            putenv('CLD_TEST_ADDONS=' . $cld_test_addons);
+        } else {
+            putenv('CLD_TEST_ADDONS');
+        }
+    }
 }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -369,4 +369,55 @@ END;
             return 1;
         }
     }
+
+    class AddOn
+    {
+        const ALL                         = 'all';                       // Test all addons.
+        const ASPOSE                      = 'aspose';                    // Aspose document conversion.
+        const AZURE                       = 'azure';                     // Microsoft azure video indexer.
+        const BG_REMOVAL                  = 'bgremoval';                 // Cloudinary AI background removal.
+        const FACIAL_ATTRIBUTES_DETECTION = 'facialattributesdetection'; // Advanced facial attributes detection.
+        const GOOGLE                      = 'google';                    // Google AI video moderation, google AI
+                                                                         // video transcription, google auto tagging,
+                                                                         // google automatic video tagging,
+                                                                         // google translation.
+        const IMAGGA                      = 'imagga';                    // Imagga auto tagging, crop and scale.
+        const JPEGMINI                    = 'jpegmini';                  // JPEGmini image optimization.
+        const LIGHTROOM                   = 'lightroom';                 // Adobe photoshop lightroom (BETA).
+        const METADEFENDER                = 'metadefender';              // MetaDefender anti-malware protection.
+        const NEURAL_ARTWORK              = 'neuralartwork';             // Neural artwork style transfer.
+        const OBJECT_AWARE_CROPPING       = 'objectawarecropping';       // Cloudinary object-aware cropping.
+        const OCR                         = 'ocr';                       // OCR text detection and extraction.
+        const PIXELZ                      = 'pixelz';                    // Remove the background.
+        const REKOGNITION                 = 'rekognition';               // Amazon rekognition AI moderation,
+                                                                         // amazon rekognition auto tagging,
+                                                                         // amazon rekognition celebrity detection.
+        const URL2PNG                     = 'url2png';                   // URL2PNG website screenshots.
+        const VIESUS                      = 'viesus';                    // VIESUS automatic image enhancement.
+        const WEBPURIFY                   = 'webpurify';                 // WebPurify image moderation.
+
+        /**
+         * Should a certain add on be tested.
+         *
+         * @param string $add_on
+         *
+         * @return bool
+         */
+        public static function should_test_add_on($add_on)
+        {
+            $cld_test_add_ons = strtolower(getenv('CLD_TEST_ADDONS'));
+            if ($cld_test_add_ons === self::ALL) {
+                return true;
+            }
+
+            return in_array(
+                strtolower($add_on),
+                array_map(
+                    'trim',
+                    explode(',', $cld_test_add_ons)
+                ),
+                false
+            );
+        }
+    }
 }


### PR DESCRIPTION
### Brief Summary of Changes

Added the `should_test_addon() ` function which can be used at the beginning of tests to determine whether a certain addon should be tested and allow skipping those that shouldn't.

To enable certain addon testing, add its id to the `CLD_TEST_ADDONS` environment variable. Alternatively set `CLD_TEST_ADDONS` to `all` to test all add ons.

#### What does this PR address?
[x] New feature

#### Are tests included?
[ ] Yes
[x] No

#### Reviewer, Please Note:

Consider adding `CLD_TEST_ADDONS=all` to Travis.