### PR TITLE
Fix metadata fields deletion after tests

### DIFF
--- a/tests/Integration/Admin/MetadataFieldsTest.php
+++ b/tests/Integration/Admin/MetadataFieldsTest.php
@@ -60,17 +60,17 @@ class MetadataFieldsTest extends IntegrationTestCase
         parent::setUpBeforeClass();
 
         $id = self::$UNIQUE_TEST_ID;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_GENERAL = 'metadata_external_id_general_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_DATE = 'metadata_external_id_date_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_ENUM_2 = 'metadata_external_id_enum_2_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_SET = 'metadata_external_id_set_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_SET_2 = 'metadata_external_id_set_2_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_SET_3 = 'metadata_external_id_set_3_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_DELETE_2 = 'metadata_deletion_test_2_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_DATE_VALIDATION = 'metadata_date_validation_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_DATE_VALIDATION_2 = 'metadata_date_validation_2_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_INT_VALIDATION = 'metadata_integer_validation_' . $id;
-        $METADATA_FIELDS[] = self::$EXTERNAL_ID_INT_VALIDATION_2 = 'metadata_integer_validation_2_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_GENERAL = 'metadata_external_id_general_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_DATE = 'metadata_external_id_date_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_ENUM_2 = 'metadata_external_id_enum_2_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_SET = 'metadata_external_id_set_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_SET_2 = 'metadata_external_id_set_2_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_SET_3 = 'metadata_external_id_set_3_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_DELETE_2 = 'metadata_deletion_test_2_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_DATE_VALIDATION = 'metadata_date_validation_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_DATE_VALIDATION_2 = 'metadata_date_validation_2_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_INT_VALIDATION = 'metadata_integer_validation_' . $id;
+        self::$METADATA_FIELDS[] = self::$EXTERNAL_ID_INT_VALIDATION_2 = 'metadata_integer_validation_2_' . $id;
         // External IDs for metadata fields that will be accessed through a mock (and should not be deleted or created)
         self::$EXTERNAL_ID_DELETE = 'metadata_deletion_test_' . $id;
         self::$EXTERNAL_ID_ENUM = 'metadata_external_id_enum_' . $id;


### PR DESCRIPTION
### Brief Summary of Changes

`MetadataFieldsTest` did not properly cleanup after itself. This PR fixes it so the fields created by the test are deleted after the test.

#### What does this PR address?
- [x] Bug fix

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
