### PR TITLE
Fix flags serialisation

### DIFF
--- a/src/Transformation/BaseAction.php
+++ b/src/Transformation/BaseAction.php
@@ -246,19 +246,7 @@ abstract class BaseAction extends BaseComponent
      */
     protected static function serializeFlags($flags)
     {
-        ksort($flags);
-
-        $result = array_map(
-            static function (FlagQualifier $flag) {
-                return ArrayUtils::implodeQualifierValues(
-                    $flag->getFlagName(),
-                    rawurlencode(StringUtils::encodeDot($flag->getValue()))
-                );
-            },
-            array_values($flags)
-        );
-
-        return (string)new FlagQualifier(ArrayUtils::implodeFiltered('.', $result));
+        return ArrayUtils::implodeActionQualifiers(...array_values($flags));
     }
 
     /**

--- a/src/Transformation/Flag/FlagQualifier.php
+++ b/src/Transformation/Flag/FlagQualifier.php
@@ -11,6 +11,7 @@
 namespace Cloudinary\Transformation;
 
 use Cloudinary\ArrayUtils;
+use Cloudinary\StringUtils;
 use Cloudinary\Transformation\Qualifier\BaseQualifier;
 
 /**
@@ -78,7 +79,10 @@ class FlagQualifier extends BaseQualifier
     {
         $flagQualifierName = $this->flagName ? self::getKey() . "_{$this->flagName}" : '';
 
-        return ArrayUtils::implodeQualifierValues($flagQualifierName, $this->value);
+        return ArrayUtils::implodeQualifierValues(
+            $flagQualifierName,
+            rawurlencode(StringUtils::encodeDot($this->value))
+        );
     }
 
     /**

--- a/src/Utils/ArrayUtils.php
+++ b/src/Utils/ArrayUtils.php
@@ -273,9 +273,11 @@ class ArrayUtils
      */
     public static function implodeActionQualifiers(...$qualifiers)
     {
-        sort($qualifiers, SORT_STRING);
+        $serializedQualifiers = array_map('strval', $qualifiers);
 
-        return self::implodeFiltered(',', $qualifiers);
+        sort($serializedQualifiers);
+
+        return self::implodeFiltered(',', $serializedQualifiers);
     }
 
     /**

--- a/tests/Unit/Transformation/Common/FormatTest.php
+++ b/tests/Unit/Transformation/Common/FormatTest.php
@@ -65,16 +65,16 @@ final class FormatTest extends TestCase
 
         $ffl->progressive(Progressive::steep())->preserveTransparency();
 
-        self::assertEquals('f_auto,fl_lossy.preserve_transparency.progressive:steep', (string)$ffl);
+        self::assertEquals('f_auto,fl_lossy,fl_preserve_transparency,fl_progressive:steep', (string)$ffl);
     }
 
     public function testAnimatedFormat()
     {
         self::assertEquals('f_auto,fl_animated', (string)AnimatedFormat::auto());
         self::assertEquals('f_gif,fl_animated', (string)AnimatedFormat::gif());
-        self::assertEquals('f_webp,fl_animated.awebp', (string)AnimatedFormat::webp());
-        self::assertEquals('f_png,fl_animated.apng', (string)AnimatedFormat::png());
+        self::assertEquals('f_webp,fl_animated,fl_awebp', (string)AnimatedFormat::webp());
+        self::assertEquals('f_png,fl_animated,fl_apng', (string)AnimatedFormat::png());
 
-        self::assertEquals('f_webp,fl_animated.awebp.lossy', (string)AnimatedFormat::webp()->lossy());
+        self::assertEquals('f_webp,fl_animated,fl_awebp,fl_lossy', (string)AnimatedFormat::webp()->lossy());
     }
 }

--- a/tests/Unit/Transformation/Image/OverUnderlayTest.php
+++ b/tests/Unit/Transformation/Image/OverUnderlayTest.php
@@ -114,7 +114,7 @@ final class OverUnderlayTest extends TestCase
     public function testOverlayPosition()
     {
         self::assertEquals(
-            'l_test/fl_layer_apply,fl_no_overflow.tiled,x_10,y_20',
+            'l_test/fl_layer_apply,fl_no_overflow,fl_tiled,x_10,y_20',
             (string)(new Transformation())
                 ->overlay(Overlay::source('test')->position(Position::absolute(10, 20)->tiled()->allowOverflow(false)))
         );

--- a/tests/Unit/Transformation/TransformationTest.php
+++ b/tests/Unit/Transformation/TransformationTest.php
@@ -72,7 +72,7 @@ final class TransformationTest extends UnitTestCase
         $t->addAction(Effect::sepia(100));
 
         $t_expected = 'b_blue,c_lpad,g_south_west,h_18,w_17/e_replace_color:green:17:red/' .
-                      'c_scale,fl_attachment:file%252Ebin.ignore_aspect_ratio,h_200,w_100/e_sepia:100';
+                      'c_scale,fl_attachment:file%252Ebin,fl_ignore_aspect_ratio,h_200,w_100/e_sepia:100';
         self::assertEquals(
             $t_expected,
             (string)$t
@@ -294,7 +294,7 @@ final class TransformationTest extends UnitTestCase
     public function testSetFlags()
     {
         self::assertEquals(
-            'fl_animated.attachment:my_file%252Ebin.tiff8_lzw',
+            'fl_animated,fl_attachment:my_file%252Ebin,fl_tiff8_lzw',
             (string)(new Transformation())
                 ->addAction(
                     Action::generic()
@@ -309,7 +309,7 @@ final class TransformationTest extends UnitTestCase
     public function testSetFlagsWithBuilders()
     {
         self::assertEquals(
-            'fl_attachment:my_file.bin/fl_sanitize/fl_mono',
+            'fl_attachment:my_file%252Ebin/fl_sanitize/fl_mono',
             (string)(new Transformation())->attachment('my_file.bin')->sanitize()->mono()
         );
     }

--- a/tests/Unit/Transformation/Video/VideoTranscodeTest.php
+++ b/tests/Unit/Transformation/Video/VideoTranscodeTest.php
@@ -32,7 +32,7 @@ final class VideoTranscodeTest extends TestCase
         );
 
         self::assertEquals(
-            'dl_5,f_webp,fl_animated.awebp,vs_10',
+            'dl_5,f_webp,fl_animated,fl_awebp,vs_10',
             (string)Transcode::toAnimated(AnimatedFormat::webp())->sampling(10)->delay(5)
         );
     }

--- a/tests/Unit/Transformation/Video/VideoTransformationTest.php
+++ b/tests/Unit/Transformation/Video/VideoTransformationTest.php
@@ -232,7 +232,7 @@ final class VideoTransformationTest extends UnitTestCase
     public function testVideoTransformationFlags()
     {
         self::assertEquals(
-            'fl_streaming_attachment:my_streaming_video.mp4',
+            'fl_streaming_attachment:my_streaming_video%252Emp4',
             (string)(new VideoTransformation())
                 ->streamingAttachment('my_streaming_video.mp4')
         );


### PR DESCRIPTION
### Brief Summary of Changes
Flags serialisation is aligned with other SDKs.
Fixed encoding of values for specific flags (like fl_attachment:filename.bin)

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
