### PR TITLE
Fix handling of array parameters in APIs

### DIFF
--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -118,16 +118,20 @@ class ApiClient extends BaseApiClient
     /**
      * Performs an HTTP POST request with the given form parameters asynchronously.
      *
+     * Please note that form parameters are encoded in a slightly different way, see Utils::buildHttpQuery for details.
+     *
      * @param string|array $endPoint   The API endpoint path.
      * @param array        $formParams The form parameters
      *
      * @return PromiseInterface
      *
+     * @see Utils::buildHttpQuery
+     *
      * @internal
      */
     public function postFormAsync($endPoint, $formParams)
     {
-        return $this->callAsync(HttpMethod::POST, $endPoint, ['form_params' => $formParams]);
+        return $this->callAsync(HttpMethod::POST, $endPoint, ['body' => Utils::buildHttpQuery($formParams)]);
     }
 
     /**

--- a/src/Api/BaseApiClient.php
+++ b/src/Api/BaseApiClient.php
@@ -24,6 +24,7 @@ use Cloudinary\Configuration\ApiConfig;
 use Cloudinary\JsonUtils;
 use Cloudinary\Log\LoggerTrait;
 use Cloudinary\StringUtils;
+use Cloudinary\Utils;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
@@ -52,15 +53,16 @@ class BaseApiClient
     /**
      * @var array Cloudinary API Error Classes mapping between http error codes and Cloudinary exceptions
      */
-    const CLOUDINARY_API_ERROR_CLASSES = [
-        StatusCode::BAD_REQUEST => BadRequest::class,
-        StatusCode::UNAUTHORIZED => AuthorizationRequired::class,
-        StatusCode::FORBIDDEN => NotAllowed::class,
-        StatusCode::NOT_FOUND => NotFound::class,
-        StatusCode::CONFLICT => AlreadyExists::class,
-        Twitter::ENHANCE_YOUR_CALM => RateLimited::class, // RFC6585::TOO_MANY_REQUESTS
-        StatusCode::INTERNAL_SERVER_ERROR => GeneralError::class,
-    ];
+    const CLOUDINARY_API_ERROR_CLASSES
+        = [
+            StatusCode::BAD_REQUEST           => BadRequest::class,
+            StatusCode::UNAUTHORIZED          => AuthorizationRequired::class,
+            StatusCode::FORBIDDEN             => NotAllowed::class,
+            StatusCode::NOT_FOUND             => NotFound::class,
+            StatusCode::CONFLICT              => AlreadyExists::class,
+            Twitter::ENHANCE_YOUR_CALM        => RateLimited::class, // RFC6585::TOO_MANY_REQUESTS
+            StatusCode::INTERNAL_SERVER_ERROR => GeneralError::class,
+        ];
 
     /**
      * @var Client The Http client instance. Performs actual network calls.
@@ -194,7 +196,7 @@ class BaseApiClient
      */
     public function delete($endPoint, $fields = [])
     {
-        return $this->callAsync(HttpMethod::DELETE, $endPoint, ['form_params' => $fields])->wait();
+        return $this->callAsync(HttpMethod::DELETE, $endPoint, ['body' => Utils::buildHttpQuery($fields)])->wait();
     }
 
     /**
@@ -256,7 +258,7 @@ class BaseApiClient
      */
     public function put($endPoint, $fields)
     {
-        return $this->callAsync(HttpMethod::PUT, $endPoint, ['form_params' => $fields])->wait();
+        return $this->callAsync(HttpMethod::PUT, $endPoint, ['body' => Utils::buildHttpQuery($fields)])->wait();
     }
 
     /**
@@ -317,6 +319,7 @@ class BaseApiClient
     {
         $endPoint = self::finalizeEndPoint($endPoint);
         $this->getLogger()->debug("Making async $method request", ['method' => $method, 'endPoint' => $endPoint]);
+
         return $this
             ->httpClient
             ->requestAsync($method, $endPoint, $options)
@@ -332,10 +335,11 @@ class BaseApiClient
                         $this->getLogger()->critical(
                             'Async request failed',
                             [
-                                'code' => $e->getCode(),
-                                'message' => $e->getMessage()
+                                'code'    => $e->getCode(),
+                                'message' => $e->getMessage(),
                             ]
                         );
+
                         return Promise\rejection_for($e);
                     }
                 },
@@ -343,8 +347,8 @@ class BaseApiClient
                     $this->getLogger()->critical(
                         'Async request failed',
                         [
-                            'code' => $error->getCode(),
-                            'message' => $error->getMessage()
+                            'code'    => $error->getCode(),
+                            'message' => $error->getMessage(),
                         ]
                     );
                     if ($error instanceof ClientException) {
@@ -391,9 +395,9 @@ class BaseApiClient
 
         if ($statusCode !== StatusCode::OK) {
             if (array_key_exists($statusCode, self::CLOUDINARY_API_ERROR_CLASSES)) {
-                $errorClass = self::CLOUDINARY_API_ERROR_CLASSES[$statusCode];
+                $errorClass   = self::CLOUDINARY_API_ERROR_CLASSES[$statusCode];
                 $responseJson = $this->parseJsonResponse($response);
-                $message = ArrayUtils::get(
+                $message      = ArrayUtils::get(
                     $responseJson['error']['message'],
                     'message',
                     $responseJson['error']['message']
@@ -402,19 +406,19 @@ class BaseApiClient
                     'Request to Cloudinary server returned an error',
                     [
                         'statusCode' => $statusCode,
-                        'message' => $message
+                        'message'    => $message,
 
                     ]
                 );
                 throw new $errorClass($message);
             }
             $message = "Server returned unexpected status code - {$response->getStatusCode()} - " .
-                StringUtils::truncateMiddle($response->getBody());
+                       StringUtils::truncateMiddle($response->getBody());
             $this->getLogger()->critical($message);
             throw new GeneralError($message);
         }
 
-        $responseJson = $this->parseJsonResponse($response);
+        $responseJson    = $this->parseJsonResponse($response);
         $responseHeaders = $response->getHeaders();
 
         return new ApiResponse($responseJson, $responseHeaders);

--- a/src/Api/BaseApiClient.php
+++ b/src/Api/BaseApiClient.php
@@ -133,7 +133,7 @@ class BaseApiClient
      */
     public function getAsync($endPoint, $queryParams = [])
     {
-        return $this->callAsync(HttpMethod::GET, $endPoint, ['query' => $queryParams]);
+        return $this->callAsync(HttpMethod::GET, $endPoint, ['query' => Utils::buildHttpQuery($queryParams)]);
     }
 
     /**
@@ -196,7 +196,7 @@ class BaseApiClient
      */
     public function delete($endPoint, $fields = [])
     {
-        return $this->callAsync(HttpMethod::DELETE, $endPoint, ['body' => Utils::buildHttpQuery($fields)])->wait();
+        return $this->callAsync(HttpMethod::DELETE, $endPoint, ['form_params' => $fields])->wait();
     }
 
     /**
@@ -258,7 +258,7 @@ class BaseApiClient
      */
     public function put($endPoint, $fields)
     {
-        return $this->callAsync(HttpMethod::PUT, $endPoint, ['body' => Utils::buildHttpQuery($fields)])->wait();
+        return $this->callAsync(HttpMethod::PUT, $endPoint, ['form_params' => $fields])->wait();
     }
 
     /**

--- a/src/Api/Upload/ArchiveTrait.php
+++ b/src/Api/Upload/ArchiveTrait.php
@@ -57,24 +57,28 @@ trait ArchiveTrait
             'version_id',
         ];
 
+        $arrayParams = [
+            'prefixes',
+            'public_ids',
+            'fully_qualified_public_ids',
+            'tags',
+            'target_tags',
+        ];
 
         $complexParams = [
-            'prefixes'                   => ApiUtils::serializeSimpleApiParam(ArrayUtils::get($options, 'prefixes')),
-            'public_ids'                 => ApiUtils::serializeSimpleApiParam(ArrayUtils::get($options, 'public_ids')),
-            'fully_qualified_public_ids' => ApiUtils::serializeSimpleApiParam(
-                ArrayUtils::get($options, 'fully_qualified_public_ids')
-            ),
-            'tags'                       => ApiUtils::serializeSimpleApiParam((ArrayUtils::get($options, 'tags'))),
-            'target_tags'                => ApiUtils::serializeSimpleApiParam(
-                (ArrayUtils::get($options, 'target_tags'))
-            ),
-            'transformations'            => ApiUtils::serializeAssetTransformations(
+            'transformations' => ApiUtils::serializeAssetTransformations(
                 ArrayUtils::get($options, 'transformations')
             ),
         ];
 
+        $arrayParamValues = [];
+
+        foreach ($arrayParams as $arrayParam) {
+            $arrayParamValues[$arrayParam] = ArrayUtils::build(ArrayUtils::get($options, $arrayParam));
+        }
+
         return ApiUtils::finalizeUploadApiParams(
-            array_merge(ArrayUtils::whitelist($options, $simpleParams), $complexParams)
+            array_merge(ArrayUtils::whitelist($options, $simpleParams), $arrayParamValues, $complexParams)
         );
     }
 
@@ -139,6 +143,7 @@ trait ArchiveTrait
      *
      * @param array      $options                 Additional options. Can be one of the following:
      *
+     * @return string The resulting archive URL.
      * @var string       $resource_type           The resource type of files to include in the archive.
      *                                     Must be one of image | video | raw.
      * @var string       $type                    The specific file delivery type of resources:
@@ -173,7 +178,6 @@ trait ArchiveTrait
      *                                     generated archive file (for later housekeeping via the admin API).
      * @var string       $keep_derived            (false) keep the derived images used for generating the archive.
      *
-     * @return string The resulting archive URL.
      */
     public function downloadArchiveUrl($options = [])
     {
@@ -229,7 +233,7 @@ trait ArchiveTrait
      */
     public function downloadBackedupAsset($assetId, $versionId)
     {
-        $options['asset_id'] = $assetId;
+        $options['asset_id']   = $assetId;
         $options['version_id'] = $versionId;
 
         $params = self::buildArchiveParams($options);

--- a/src/Api/Upload/ContextTrait.php
+++ b/src/Api/Upload/ContextTrait.php
@@ -104,7 +104,7 @@ trait ContextTrait
     {
         $params = [
             'context'    => ApiUtils::serializeContext($context),
-            'public_ids' => ApiUtils::serializeSimpleApiParam($publicIds),
+            'public_ids' => ArrayUtils::build($publicIds),
             'type'       => ArrayUtils::get($options, 'type'),
             'command'    => $command,
         ];

--- a/src/Api/Upload/UploadApi.php
+++ b/src/Api/Upload/UploadApi.php
@@ -15,6 +15,7 @@ use Cloudinary\Api\ApiUtils;
 use Cloudinary\ArrayUtils;
 use Cloudinary\Asset\AssetType;
 use Cloudinary\Configuration\CloudConfig;
+use Cloudinary\Utils;
 use GuzzleHttp\Promise\PromiseInterface;
 
 /**
@@ -78,7 +79,7 @@ class UploadApi
         $baseUrl = $this->apiClient->getBaseUri();
         $path    = self::getUploadApiEndPoint($endPoint, ['resource_type' => $assetType]);
 
-        return ArrayUtils::implodeFiltered('?', ["{$baseUrl}{$path}", http_build_query($params)]);
+        return ArrayUtils::implodeFiltered('?', ["{$baseUrl}{$path}", Utils::buildHttpQuery($params)]);
     }
 
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -220,6 +220,36 @@ class Utils
     }
 
     /**
+     * Fixes array encoding.
+     *
+     * http_build_query encodes a simple array:
+     *   $arr = ['v0', 'v1', ... ,'vn1]
+     * as:
+     *   arr[0]=v0&arr[1]=v1&...&arr[n]=vn
+     *
+     * The issue with this encoding, is that on the server not written in PHP,
+     * this query is parsed as an associative array/hashmap/dictionary of form:
+     *   {
+     *      '0' : 'v0',
+     *      '1' : 'v1',
+     *      ...
+     *      'n' : 'vn'
+     *   }
+     *
+     * To avoid this undesired behaviour, indices must be removed, so the query string would look like:
+     * arr[]=v0&arr[]=v1&...&arr[]=vn
+     *
+     * @param array $params The query params to encode.
+     *
+     * @return string|string[]|null
+     */
+    public static function buildHttpQuery($params)
+    {
+        return preg_replace("/%5B\d+%5D/", "%5B%5D", http_build_query($params));
+    }
+
+
+    /**
      * Returns current UNIX time in seconds.
      *
      * @return int

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -222,18 +222,20 @@ class Utils
     /**
      * Fixes array encoding.
      *
-     * http_build_query encodes a simple array:
-     *   $arr = ['v0', 'v1', ... ,'vn1]
+     * http_build_query encodes a simple array value:
+     *   ['arr' => [v0', 'v1', ... ,'vn1]]
      * as:
      *   arr[0]=v0&arr[1]=v1&...&arr[n]=vn
      *
-     * The issue with this encoding, is that on the server not written in PHP,
+     * The issue with this encoding is that on the server written not in PHP,
      * this query is parsed as an associative array/hashmap/dictionary of form:
      *   {
-     *      '0' : 'v0',
-     *      '1' : 'v1',
-     *      ...
-     *      'n' : 'vn'
+     *     "arr": {
+     *       "0" : "v0",
+     *       "1" : "v1",
+     *       ...
+     *       "n" : "vn"
+     *     }
      *   }
      *
      * To avoid this undesired behaviour, indices must be removed, so the query string would look like:

--- a/tests/CloudinaryTestCase.php
+++ b/tests/CloudinaryTestCase.php
@@ -20,7 +20,7 @@ use ReflectionException;
 use ReflectionMethod;
 
 
-if (!defined('JSON_INVALID_UTF8_SUBSTITUTE')) {
+if (! defined('JSON_INVALID_UTF8_SUBSTITUTE')) {
     //PHP < 7.2 Define it as 0 so it does nothing
     define('JSON_INVALID_UTF8_SUBSTITUTE', 0);
 }
@@ -39,6 +39,7 @@ abstract class CloudinaryTestCase extends TestCase
     protected static $UNIQUE_TEST_TAG;
     protected static $ASSET_TAGS;
     protected static $UNIQUE_TEST_ID;
+    protected static $UNIQUE_TEST_ID2;
 
     protected static $skipAllTests = false;
     protected static $skipReason;
@@ -47,11 +48,12 @@ abstract class CloudinaryTestCase extends TestCase
     {
         parent::setUpBeforeClass();
 
-        self::$SUFFIX = getenv('TRAVIS_JOB_ID') ?: mt_rand(11111, 99999);
-        self::$TEST_TAG = 'cloudinary_php_v' . str_replace(['.', '-'], '_', Cloudinary::VERSION);
+        self::$SUFFIX          = getenv('TRAVIS_JOB_ID') ?: mt_rand(11111, 99999);
+        self::$TEST_TAG        = 'cloudinary_php_v' . str_replace(['.', '-'], '_', Cloudinary::VERSION);
         self::$UNIQUE_TEST_TAG = self::$TEST_TAG . '_' . self::$SUFFIX;
-        self::$UNIQUE_TEST_ID = self::$UNIQUE_TEST_TAG;
-        self::$ASSET_TAGS = [self::$TEST_TAG, self::$UNIQUE_TEST_TAG];
+        self::$UNIQUE_TEST_ID  = self::$UNIQUE_TEST_TAG;
+        self::$UNIQUE_TEST_ID2 = self::$UNIQUE_TEST_ID . '_2';
+        self::$ASSET_TAGS      = [self::$TEST_TAG, self::$UNIQUE_TEST_TAG];
     }
 
     /**
@@ -175,6 +177,7 @@ abstract class CloudinaryTestCase extends TestCase
         } catch (ReflectionException $e) {
             // oops
             self::fail((string)$e);
+
             // we actually never get here
             return null;
         }

--- a/tests/Integration/Upload/ContextTest.php
+++ b/tests/Integration/Upload/ContextTest.php
@@ -20,6 +20,7 @@ final class ContextTest extends IntegrationTestCase
         parent::setUpBeforeClass();
 
         self::uploadTestAssetImage(['public_id' => self::$UNIQUE_TEST_ID]);
+        self::uploadTestAssetImage(['public_id' => self::$UNIQUE_TEST_ID2]);
     }
 
     public static function tearDownAfterClass()
@@ -49,14 +50,17 @@ final class ContextTest extends IntegrationTestCase
     public function testRemoveAllContextFromImagesByPublicIDsArray()
     {
         self::$uploadApi->addContext(self::CONTEXT_DATA, [self::$UNIQUE_TEST_ID]);
+        self::$uploadApi->addContext(self::CONTEXT_DATA, [self::$UNIQUE_TEST_ID2]);
 
-        $result = self::$uploadApi->removeAllContext([self::$UNIQUE_TEST_ID]);
+        $result = self::$uploadApi->removeAllContext([self::$UNIQUE_TEST_ID, self::$UNIQUE_TEST_ID2]);
 
-        self::assertEquals([self::$UNIQUE_TEST_ID], $result['public_ids']);
+        self::assertEquals([self::$UNIQUE_TEST_ID, self::$UNIQUE_TEST_ID2], $result['public_ids']);
 
         $resource = self::$adminApi->asset(self::$UNIQUE_TEST_ID);
+        $resource2 = self::$adminApi->asset(self::$UNIQUE_TEST_ID2);
 
         self::assertArrayNotHasKey('context', $resource);
+        self::assertArrayNotHasKey('context', $resource2);
     }
 
     /**


### PR DESCRIPTION
### Brief Summary of Changes
Cloudinary server expects array parameters to be encoded as:
`arr[]=v0&arr[]=v1&...&arr[]=vn`
opposed to PHP behaviour:
 `arr[0]=v0&arr[1]=v1&...&arr[n]=vn`
 
 This PR fixes array encoding.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
