### PR TITLE
Fix `PositiveFloatValue` error when value cannot be cast to string

### DIFF
--- a/src/Transformation/Qualifier/QualifierValue/Misc/PositiveFloatValue.php
+++ b/src/Transformation/Qualifier/QualifierValue/Misc/PositiveFloatValue.php
@@ -40,6 +40,9 @@ class PositiveFloatValue extends QualifierMultiValue
         }
 
         if (! is_numeric($floatValue)) {
+            if (!method_exists($floatValue, '__toString')) {
+                throw new InvalidArgumentException("Argument should be a number or a string");
+            }
             throw new InvalidArgumentException("'$floatValue' should be a number or a string");
         }
         if ($floatValue < 0) {

--- a/tests/Unit/Transformation/Video/Audio/VideoAudioTest.php
+++ b/tests/Unit/Transformation/Video/Audio/VideoAudioTest.php
@@ -16,6 +16,7 @@ use Cloudinary\Transformation\AudioFrequency;
 use Cloudinary\Transformation\Fps;
 use Cloudinary\Transformation\KeyframeInterval;
 use Cloudinary\Transformation\Timeline;
+use InvalidArgumentException;
 
 /**
  * Class VideoAudioTest
@@ -109,5 +110,47 @@ final class VideoAudioTest extends UnitTestCase
                 (string)new KeyframeInterval($value[0])
             );
         }
+    }
+
+
+    /**
+     * Data provider for testExceptionsKeyframeInterval().
+     *
+     * @return array[]
+     */
+    public function exceptionsKeyframeIntervalDataProvider()
+    {
+        return [
+            [
+                'exceptionClass' => InvalidArgumentException::class,
+                'exceptionMessage' => 'No more than 1 argument is expected',
+                'args' => [1, 2]
+            ],
+            [
+                'exceptionClass' => InvalidArgumentException::class,
+                'exceptionMessage' => "'-1' should be greater than zero",
+                'args' => [-1],
+            ],
+            [
+                'exceptionClass' => InvalidArgumentException::class,
+                'exceptionMessage' => "Argument should be a number or a string",
+                'args' => [['a' => 2]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider exceptionsKeyframeIntervalDataProvider
+     *
+     * @param string $exceptionClass
+     * @param string $exceptionMessage
+     * @param array  $args
+     */
+    public function testExceptionsKeyframeInterval($exceptionClass, $exceptionMessage, $args)
+    {
+        $this->expectException($exceptionClass);
+        $this->expectExceptionMessage($exceptionMessage);
+
+        new KeyframeInterval(...$args);
     }
 }


### PR DESCRIPTION
### Brief Summary of Changes

Passing a parameter that cannot be cast to a string causes `PositiveFloatValue` to break.

For example, the following code would cause an _array to string conversion_ error.
```php
new KeyframeInterval(['2']);
```

Bug fixed. Additional tests added.

#### What does this PR address?
- [x] Bug fix

#### Are tests included?
- [x] Yes

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
