### PR TITLE
Fix encoding of arrays in structured metadata

### DIFF
--- a/src/Api/Utils/ApiUtils.php
+++ b/src/Api/Utils/ApiUtils.php
@@ -76,6 +76,10 @@ class ApiUtils
      */
     public static function serializeContext($context)
     {
+        if (is_array($context)) {
+            $context = array_map('\Cloudinary\Api\ApiUtils::serializeJson', $context);
+        }
+
         return self::serializeParameter($context, self::CONTEXT_OUTER_DELIMITER, self::CONTEXT_INNER_DELIMITER);
     }
 
@@ -92,6 +96,11 @@ class ApiUtils
     {
         if ($jsonParam === null) {
             return null;
+        }
+
+        // Avoid extra double quotes around strings.
+        if (is_string($jsonParam) || method_exists($jsonParam, '__toString')) {
+            return $jsonParam;
         }
 
         return json_encode($jsonParam); //TODO: serialize dates
@@ -204,7 +213,7 @@ class ApiUtils
      */
     public static function serializeResponsiveBreakpoints($breakpoints)
     {
-        if (!$breakpoints) {
+        if (! $breakpoints) {
             return null;
         }
         $breakpointsParams = [];

--- a/tests/Integration/Admin/MetadataFieldsTest.php
+++ b/tests/Integration/Admin/MetadataFieldsTest.php
@@ -137,7 +137,7 @@ class MetadataFieldsTest extends IntegrationTestCase
      * @param array       $values        An associative array where the key is the name of the parameter to check
      *                                   and the value is the value.
      */
-    private static function assertMetadataField($metadataField, $type = null, $values = array())
+    private static function assertMetadataField($metadataField, $type = null, $values = [])
     {
         self::assertInternalType(IsType::TYPE_STRING, $metadataField['external_id']);
         if ($type) {

--- a/tests/Integration/Upload/UploadApiTest.php
+++ b/tests/Integration/Upload/UploadApiTest.php
@@ -14,6 +14,7 @@ use Cloudinary\Api\Exception\ApiError;
 use Cloudinary\Api\Exception\GeneralError;
 use Cloudinary\Api\Metadata\SetMetadataField;
 use Cloudinary\Api\Metadata\StringMetadataField;
+use Cloudinary\ArrayUtils;
 use Cloudinary\Asset\AssetType;
 use Cloudinary\Asset\DeliveryType;
 use Cloudinary\FileUtils;
@@ -71,7 +72,7 @@ final class UploadApiTest extends IntegrationTestCase
         self::$METADATA_FIELD_UNIQUE_EXTERNAL_ID = 'metadata_field_external_id_' . self::$UNIQUE_TEST_ID;
         self::$METADATA_FIELD_VALUE              = 'metadata_field_value_' . self::$UNIQUE_TEST_ID;
 
-        self::$METADATA_FIELD_EXTERNAL_ID_SET = 'metadata_external_id_set_' . self::$UNIQUE_TEST_ID;
+        self::$METADATA_FIELD_EXTERNAL_ID_SET = 'metadata_external_id_uploader_set_' . self::$UNIQUE_TEST_ID;
         self::$DATASOURCE_ENTRY_EXTERNAL_ID   = 'metadata_datasource_entry_external_id' . self::$UNIQUE_TEST_ID;
         self::$DATASOURCE_ENTRY_EXTERNAL_ID2  = 'metadata_datasource_entry_external_id2' . self::$UNIQUE_TEST_ID;
 
@@ -380,8 +381,8 @@ final class UploadApiTest extends IntegrationTestCase
         );
 
         self::assertEquals(
-            self::$METADATA_FIELD_VALUE,
-            $asset['metadata'][self::$METADATA_FIELD_UNIQUE_EXTERNAL_ID]
+            self::$METADATA_FIELDS,
+            ArrayUtils::whitelist($asset['metadata'], array_keys(self::$METADATA_FIELDS))
         );
     }
 
@@ -404,8 +405,8 @@ final class UploadApiTest extends IntegrationTestCase
         );
 
         self::assertEquals(
-            self::$METADATA_FIELDS[self::$METADATA_FIELD_UNIQUE_EXTERNAL_ID],
-            $result['metadata'][self::$METADATA_FIELD_UNIQUE_EXTERNAL_ID]
+            self::$METADATA_FIELDS,
+            ArrayUtils::whitelist($result['metadata'], array_keys(self::$METADATA_FIELDS))
         );
     }
 

--- a/tests/Unit/Utils/ApiUtilsTest.php
+++ b/tests/Unit/Utils/ApiUtilsTest.php
@@ -176,6 +176,10 @@ final class ApiUtilsTest extends TestCase
                 'value' => ['caption' => 'cap=caps', 'alt' => 'alternative|alt=a'],
                 'result' => 'caption=cap\=caps|alt=alternative\|alt\=a',
             ],
+            [
+                'value' => ['caption' => ['cap1', 'cap2'], 'alt' => ['a|"a"', 'b="b"']],
+                'result' => 'caption=["cap1","cap2"]|alt=["a\|\"a\"","b\=\"b\""]',
+            ],
         ];
     }
 


### PR DESCRIPTION
### Brief Summary of Changes
Fix encoding of arrays in `enum` and `set` structured metadata fields.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
