### PR TITLE
Add `filename_override` upload parameter

### DIFF
--- a/src/Api/Upload/UploadTrait.php
+++ b/src/Api/Upload/UploadTrait.php
@@ -56,6 +56,7 @@ trait UploadTrait
             'eval',
             'exif',
             'faces',
+            'filename_override',
             'folder',
             'format',
             'image_metadata',

--- a/tests/Integration/Upload/UploadApiTest.php
+++ b/tests/Integration/Upload/UploadApiTest.php
@@ -504,4 +504,23 @@ final class UploadApiTest extends IntegrationTestCase
         self::assertRegExp('/\.gif$/', $asset['responsive_breakpoints'][0]['breakpoints'][0]['url']);
         self::assertRegExp('/\.gif$/', $asset['responsive_breakpoints'][0]['breakpoints'][0]['secure_url']);
     }
+
+    /**
+     * Should successfully override original_filename.
+     *
+     * @throws ApiError
+     */
+    public function testFilenameOverride()
+    {
+        $asset = self::$uploadApi->upload(
+            'http://cloudinary.com/images/old_logo.png',
+            [
+                'filename_override' => 'overridden',
+                'tags' => self::$ASSET_TAGS
+            ]
+        );
+
+        self::assertValidAsset($asset);
+        self::assertEquals('overridden', $asset['original_filename']);
+    }
 }


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->
A new parameter 'filename_override' was added to upload API. It is used to determine the original-filename stored on the resource metadata (e.g. for 'use_filename' / download flows)

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
