### PR TITLE
Complex expressions now produce correct results

### DIFF
--- a/src/Transformation/Expression/ExpressionUtils.php
+++ b/src/Transformation/Expression/ExpressionUtils.php
@@ -91,7 +91,7 @@ class ExpressionUtils
         }
 
         if (empty(self::$IF_REPLACE_RE)) {
-            self::$IF_REPLACE_RE = '/((\|\||>=|<=|&&|!=|>|=|<|\/|\-|\+|\*|\^)(?=[ _])|(?<![\$\:])(' .
+            self::$IF_REPLACE_RE = '/((\$_*[^_]+)|(\|\||>=|<=|&&|!=|>|=|<|\/|\-|\+|\*|\^)(?=[ _])|(?<![\$\:])(' .
                                    implode('|', array_keys(self::$PREDEFINED_VARIABLES)) .
                                    '))/';
         }

--- a/tests/Unit/Transformation/Expression/ExpressionTest.php
+++ b/tests/Unit/Transformation/Expression/ExpressionTest.php
@@ -13,6 +13,7 @@ namespace Cloudinary\Test\Unit\Transformation\Expression;
 use Cloudinary\Transformation\Crop;
 use Cloudinary\Transformation\Expression\Expression;
 use Cloudinary\Transformation\Expression\ExpressionComponent;
+use Cloudinary\Transformation\Expression\ExpressionUtils;
 use Cloudinary\Transformation\Expression\LogicalOperator;
 use Cloudinary\Transformation\Expression\PVar;
 use Cloudinary\Transformation\Expression\RelationalOperator;
@@ -116,5 +117,63 @@ final class ExpressionTest extends TestCase
         self::assertEquals($expectedExpr, (string)$rawExpr);
 
         self::assertEquals($expectedExpr . '_gt_997', (string)$rawExpr->greaterThan()->numeric(997));
+    }
+
+    /**
+     * Check expression normalization
+     *
+     * @dataProvider testNormalizationDataProvider
+     *
+     * @param mixed       $input          Value to normalize
+     * @param null|string $expectedOutput Expected normalized output
+     */
+    public function testExpressionNormalization($input, $expectedOutput)
+    {
+        $actual = ExpressionUtils::normalize($input);
+        self::assertEquals($expectedOutput, $actual);
+    }
+
+    /**
+     * Data provider for testExpressionNormalization
+     *
+     * @return array[]
+     */
+    public static function testNormalizationDataProvider()
+    {
+        return [
+            'null is not affected' => [null, null],
+            'number replaced with a string value' => [10, '10'],
+            'empty string is not affected' => ['', ''],
+            'single space is replaced with a single underscore' => [' ', '_'],
+            'blank string is replaced with a single underscore' => ['   ', '_'],
+            'underscore is not affected' => ['_', '_'],
+            'sequence of underscores and spaces is replaced with a single underscore' => [' _ __  _', '_'],
+            'arbitrary text is not affected' => ['foobar', 'foobar'],
+            'double ampersand replaced with and operator' => ['foo && bar', 'foo_and_bar'],
+            'double ampersand with no space at the end is not affected' => ['foo&&bar', 'foo&&bar'],
+            'width recognized as variable and replaced with w' => ['width', 'w'],
+            'initial aspect ratio recognized as variable and replaced with iar' => ['initial_aspect_ratio', 'iar'],
+            '$width recognized as user variable and not affected' => ['$width', '$width'],
+            '$initial_aspect_ratio recognized as user variable followed by aspect_ratio variable' => [
+                '$initial_aspect_ratio',
+                '$initial_ar',
+            ],
+            '$mywidth recognized as user variable and not affected' => ['$mywidth', '$mywidth'],
+            '$widthwidth recognized as user variable and not affected' => ['$widthwidth', '$widthwidth'],
+            '$_width recognized as user variable and not affected' => ['$_width', '$_width'],
+            '$__width recognized as user variable and not affected' => ['$__width', '$_width'],
+            '$$width recognized as user variable and not affected' => ['$$width', '$$width'],
+            '$height recognized as user variable and not affected' => ['$height_100', '$height_100'],
+            '$heightt_100 recognized as user variable and not affected' => ['$heightt_100', '$heightt_100'],
+            '$$height_100 recognized as user variable and not affected' => ['$$height_100', '$$height_100'],
+            '$heightmy_100 recognized as user variable and not affected' => ['$heightmy_100', '$heightmy_100'],
+            '$myheight_100 recognized as user variable and not affected' => ['$myheight_100', '$myheight_100'],
+            '$heightheight_100 recognized as user variable and not affected' => [
+                '$heightheight_100',
+                '$heightheight_100',
+            ],
+            '$theheight_100 recognized as user variable and not affected' => ['$theheight_100', '$theheight_100'],
+            '$__height_100 recognized as user variable and not affected' => ['$__height_100', '$_height_100']
+        ];
     }
 }

--- a/tests/Unit/Transformation/TransformationTest.php
+++ b/tests/Unit/Transformation/TransformationTest.php
@@ -31,6 +31,7 @@ use Cloudinary\Transformation\Flag;
 use Cloudinary\Transformation\FocalGravity;
 use Cloudinary\Transformation\FocusOn;
 use Cloudinary\Transformation\Format;
+use Cloudinary\Transformation\GenericResize;
 use Cloudinary\Transformation\Gravity;
 use Cloudinary\Transformation\ImageTransformation;
 use Cloudinary\Transformation\Overlay;
@@ -581,5 +582,27 @@ final class TransformationTest extends UnitTestCase
                 ->resize(Resize::crop()->width(300)->height(250)->x(30))
                 ->roundCorners(RoundCorners::byRadius(60))
         );
+    }
+
+    /**
+     * Tests that user variable names containing predefined names are not affected by normalization
+     */
+    public function testUserVariableNamesContainingPredefinedNamesAreNotAffected()
+    {
+        $transformation = (new Transformation())
+            ->addVariable('$mywidth', 100)
+            ->addVariable('$aheight', 300)
+            ->resize(
+                GenericResize::generic(
+                    '',
+                    '3 + $mywidth * 3 + 4 / 2 * initialWidth * $mywidth',
+                    '3 * initialHeight + $aheight'
+                )
+            );
+
+         self::assertEquals(
+             '$mywidth_100/$aheight_300/h_3_mul_ih_add_$aheight,w_3_add_$mywidth_mul_3_add_4_div_2_mul_iw_mul_$mywidth',
+             (string)$transformation
+         );
     }
 }


### PR DESCRIPTION
### Brief Summary of Changes

User-defined variables which contain a string that matches a predefined variable (but does not start with that string) should not be affected when normalized.

For example `$myheight_100` should not be normalized to `$myh_100` but remain `$myheight_100`.

This PR fixes this and other similar cases.

#### What does this PR address?
- [x] Bug fix

#### Are tests included?
- [x] Yes
- [ ] No

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
