### PR TITLE
Add validation to AuthToken to enforce url or acl in the object

### DIFF
--- a/src/Asset/AuthToken.php
+++ b/src/Asset/AuthToken.php
@@ -109,18 +109,18 @@ class AuthToken
     /**
      *  Generates an authorization token.
      *  Options:
-     *      number start_time - the start time of the token in seconds from epoch
-     *      string expiration - the expiration time of the token in seconds from epoch
-     *      string duration - the duration of the token (from start_time)
-     *      string ip - the IP address of the client
-     *      string acl - the ACL for the token
-     *      string url - the URL to authentication in case of a URL token
+     *      number start_time - the start time of the token in seconds from epoch.
+     *      string expiration - the expiration time of the token in seconds from epoch.
+     *      string duration - the duration of the token (from start_time).
+     *      string ip - the IP address of the client.
+     *      string acl - the ACL for the token.
+     *      string url - the URL to authentication in case of a URL token.
      *
-     * @param null|string $path url path to sign. Ignored if acl is set
+     * @param null|string $path url path to sign. Ignored if acl is set.
      *
-     * @return string The authorization token
+     * @return string The authorization token.
      *
-     * @throws UnexpectedValueException if neither expiration nor duration were provided
+     * @throws UnexpectedValueException if neither expiration nor duration nor one of acl or url were provided.
      */
     public function generate($path = null)
     {
@@ -129,6 +129,10 @@ class AuthToken
         }
 
         list($start, $expiration) = $this->handleLifetime();
+
+        if (empty($path) && empty($this->config->acl)) {
+            throw new UnexpectedValueException('AuthToken must contain either acl or url property');
+        }
 
         $tokenParts = [];
 

--- a/tests/Unit/Asset/AssetAuthTokenTest.php
+++ b/tests/Unit/Asset/AssetAuthTokenTest.php
@@ -10,9 +10,11 @@
 
 namespace Cloudinary\Test\Unit\Asset;
 
+use Cloudinary\Asset\AuthToken;
 use Cloudinary\Asset\Image;
 use Cloudinary\Asset\DeliveryType;
 use Cloudinary\Transformation\Scale;
+use UnexpectedValueException;
 
 /**
  * Class AuthTokenTest
@@ -146,5 +148,27 @@ class AssetAuthTokenTest extends AuthTokenTestCase
             ]
         );
     }
-}
 
+    public function testShouldThrowWhenAclAndUrlAreMissing()
+    {
+        $authToken = new AuthToken();
+        $authToken->config->startTime = self::START_TIME;
+        $authToken->config->duration = self::DURATION;
+        $authToken->config->acl = self::AUTH_TOKEN_TEST_CONFIG_ACL;
+        $authToken->generate();
+
+        $authToken = new AuthToken();
+        $authToken->config->startTime = self::START_TIME;
+        $authToken->config->duration = self::DURATION;
+        $authToken->generate(self::AUTH_TOKEN_TEST_PATH);
+
+        $authToken = new AuthToken();
+        $authToken->config->startTime = self::START_TIME;
+        $authToken->config->duration = self::DURATION;
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('AuthToken must contain either acl or url property');
+
+        $authToken->generate();
+    }
+}

--- a/tests/Unit/Asset/AuthTokenTestCase.php
+++ b/tests/Unit/Asset/AuthTokenTestCase.php
@@ -23,7 +23,9 @@ class AuthTokenTestCase extends AssetTestCase
     const DURATION   = 300;
     const START_TIME = 11111111;
 
-    const AUTH_TOKEN_TEST_IMAGE = 'sample.jpg';
+    const AUTH_TOKEN_TEST_IMAGE      = 'sample.jpg';
+    const AUTH_TOKEN_TEST_CONFIG_ACL = '/*/t_foobar';
+    const AUTH_TOKEN_TEST_PATH       = 'http://res.cloudinary.com/test123/image/upload/v1486020273/sample.jpg';
 
     public function setUp()
     {


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

If neither acl nor URL is set for AuthToken throw error on generation 

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
