### PR TITLE
Add OAuth support to Admin Api calls

### DIFF
--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -23,6 +23,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\LimitStream;
+use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -53,17 +54,7 @@ class ApiClient extends BaseApiClient
 
         $this->baseUri = "{$this->api->uploadPrefix}/" . self::apiVersion() . "/{$this->cloud->cloudName}/";
 
-        $clientConfig = [
-            'auth'            => [$this->cloud->apiKey, $this->cloud->apiSecret],
-            'base_uri'        => $this->baseUri,
-            'connect_timeout' => $this->api->connectionTimeout,
-            'timeout'         => $this->api->timeout,
-            'proxy'           => $this->api->apiProxy,
-            'headers'         => ['User-Agent' => self::userAgent()],
-            'http_errors'     => false, // We handle HTTP errors by ourselves and throw corresponding exceptions
-        ];
-
-        $this->httpClient = new Client($clientConfig);
+        $this->httpClient = new Client($this->buildHttpClientConfig());
     }
 
     /**
@@ -91,7 +82,7 @@ class ApiClient extends BaseApiClient
     {
         $tempConfiguration = new Configuration($configuration); // TODO: improve performance here
 
-        $tempConfiguration->cloud->assertNotEmpty(['cloudName', 'apiKey', 'apiSecret']);
+        self::validateAuthorization($tempConfiguration->cloud);
 
         $this->cloud   = $tempConfiguration->cloud;
         $this->api     = $tempConfiguration->api;
@@ -367,6 +358,38 @@ class ApiClient extends BaseApiClient
     }
 
     /**
+     * Build configuration used by HTTP client
+     *
+     * @return array
+     *
+     * @internal
+     *
+     */
+    private function buildHttpClientConfig()
+    {
+        $clientConfig = [
+            'base_uri'        => $this->baseUri,
+            'connect_timeout' => $this->api->connectionTimeout,
+            'timeout'         => $this->api->timeout,
+            'proxy'           => $this->api->apiProxy,
+            'headers'         => ['User-Agent' => self::userAgent()],
+            'http_errors'     => false, // We handle HTTP errors by ourselves and throw corresponding exceptions
+        ];
+
+        if (empty($this->cloud->oauthToken)) {
+            $authConfig = [
+                'auth' => [$this->cloud->apiKey, $this->cloud->apiSecret]
+            ];
+        } else {
+            $authConfig = [
+               'headers' => ['Authorization' => 'Bearer ' . $this->cloud->oauthToken]
+            ];
+        }
+
+        return array_merge_recursive($clientConfig, $authConfig);
+    }
+
+    /**
      * Builds multipart request body from an array of parameters
      *
      * @param array $parameters The input parameters
@@ -385,5 +408,25 @@ class ApiClient extends BaseApiClient
                 $parameters
             )
         );
+    }
+
+    /**
+     * Validates if all required authorization params are passed
+     *
+     * @param CloudConfig $cloudConfig Config to validate
+     *
+     * @throws InvalidArgumentException In case not all required keys are set.
+     *
+     * @internal
+     */
+    private static function validateAuthorization($cloudConfig)
+    {
+        $keysToValidate = ['cloudName'];
+
+        if (empty($cloudConfig->oauthToken)) {
+            array_push($keysToValidate, 'apiKey', 'apiSecret');
+        }
+
+        $cloudConfig->assertNotEmpty($keysToValidate);
     }
 }

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -376,13 +376,13 @@ class ApiClient extends BaseApiClient
             'http_errors'     => false, // We handle HTTP errors by ourselves and throw corresponding exceptions
         ];
 
-        if (empty($this->cloud->oauthToken)) {
+        if (isset($this->cloud->oauthToken)) {
             $authConfig = [
-                'auth' => [$this->cloud->apiKey, $this->cloud->apiSecret]
+                'headers' => ['Authorization' => 'Bearer ' . $this->cloud->oauthToken]
             ];
         } else {
             $authConfig = [
-               'headers' => ['Authorization' => 'Bearer ' . $this->cloud->oauthToken]
+                'auth' => [$this->cloud->apiKey, $this->cloud->apiSecret]
             ];
         }
 
@@ -411,7 +411,7 @@ class ApiClient extends BaseApiClient
     }
 
     /**
-     * Validates if all required authorization params are passed
+     * Validates if all required authorization params are passed.
      *
      * @param CloudConfig $cloudConfig Config to validate
      *

--- a/src/Configuration/CloudConfig.php
+++ b/src/Configuration/CloudConfig.php
@@ -25,14 +25,15 @@ class CloudConfig extends BaseConfigSection
     const CONFIG_NAME = 'cloud';
 
     // Supported parameters
-    const CLOUD_NAME = 'cloud_name';
-    const API_KEY    = 'api_key';
-    const API_SECRET = 'api_secret';
+    const CLOUD_NAME  = 'cloud_name';
+    const API_KEY     = 'api_key';
+    const API_SECRET  = 'api_secret';
+    const OAUTH_TOKEN = 'oauth_token';
 
     /**
      * @var array of configuration keys that contain sensitive data that should not be exported (for example api key)
      */
-    protected static $sensitiveDataKeys = [self::API_KEY, self::API_SECRET];
+    protected static $sensitiveDataKeys = [self::API_KEY, self::API_SECRET, self::OAUTH_TOKEN];
 
     /**
      * Mandatory. The name of your Cloudinary cloud. Used to build the public URL for all your media assets.
@@ -58,13 +59,20 @@ class CloudConfig extends BaseConfigSection
     public $apiSecret;
 
     /**
+     * Optional for sever-side operations. Can be passed instead of passing API key and API secret.
+     *
+     * @var string
+     */
+    public $oauthToken;
+
+    /**
      * Serialises configuration section to a string representation.
      *
      * @return string
      */
     public function __toString()
     {
-        return $this->toString([self::CLOUD_NAME, self::API_KEY, self::API_SECRET]);
+        return $this->toString([self::CLOUD_NAME, self::API_KEY, self::API_SECRET, self::OAUTH_TOKEN]);
     }
 
 

--- a/src/Configuration/CloudConfig.php
+++ b/src/Configuration/CloudConfig.php
@@ -72,7 +72,7 @@ class CloudConfig extends BaseConfigSection
      */
     public function __toString()
     {
-        return $this->toString([self::CLOUD_NAME, self::API_KEY, self::API_SECRET, self::OAUTH_TOKEN]);
+        return $this->toString([self::CLOUD_NAME, self::API_KEY, self::API_SECRET]);
     }
 
 

--- a/src/Configuration/CloudConfigTrait.php
+++ b/src/Configuration/CloudConfigTrait.php
@@ -32,6 +32,20 @@ trait CloudConfigTrait
     }
 
     /**
+     * Sets the OAuth2.0 token.
+     *
+     * @param string $oauthToken Used instead of API key and API secret
+     *
+     * @return $this
+     *
+     * @api
+     */
+    public function oauthToken($oauthToken)
+    {
+        return $this->setCloudConfig(CloudConfig::OAUTH_TOKEN, $oauthToken);
+    }
+
+    /**
      * Sets the Cloud configuration key with the specified value.
      *
      * @param string $configKey   The configuration key.

--- a/src/Configuration/ConfigUtils.php
+++ b/src/Configuration/ConfigUtils.php
@@ -71,7 +71,7 @@ class ConfigUtils
         ArrayUtils::addNonEmpty($cloud, CloudConfig::API_KEY, ArrayUtils::get($userPass, 0));
         ArrayUtils::addNonEmpty($cloud, CloudConfig::API_SECRET, ArrayUtils::get($userPass, 1));
 
-        $config = array_merge($qParams, [CloudConfig::CONFIG_NAME => $cloud]);
+        $config = array_merge_recursive($qParams, [CloudConfig::CONFIG_NAME => $cloud]);
 
         $isPrivateCdn = ! empty($uri->getPath()) && $uri->getPath() !== '/';
         if ($isPrivateCdn) {

--- a/tests/Integration/Admin/OAuthTest.php
+++ b/tests/Integration/Admin/OAuthTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the Cloudinary PHP package.
+ *
+ * (c) Cloudinary
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cloudinary\Test\Integration\Admin;
+
+use Cloudinary\Api\Admin\AdminApi;
+use Cloudinary\Configuration\Configuration;
+use Cloudinary\Configuration\ConfigUtils;
+use Cloudinary\Test\Integration\IntegrationTestCase;
+
+/**
+ * Class OAuthTest
+ */
+final class OAuthTest extends IntegrationTestCase
+{
+    private static $UNIQUE_IMAGE_PUBLIC_ID;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        self::$UNIQUE_IMAGE_PUBLIC_ID = 'asset_image_' . self::$UNIQUE_TEST_ID;
+    }
+
+    public function testOAuthToken()
+    {
+        $config = ConfigUtils::parseCloudinaryUrl(getenv(Configuration::CLOUDINARY_URL_ENV_VAR));
+        $config = array_merge_recursive(['cloud' => ['oauth_token' => 'not_a_real_token']], $config);
+        $adminApi = new AdminApi($config);
+
+        $this->expectExceptionMessage('Invalid token');
+
+        $adminApi->asset(self::$UNIQUE_IMAGE_PUBLIC_ID, ['oauth_token' => 'not_a_real_token']);
+    }
+}

--- a/tests/Integration/Admin/OAuthTest.php
+++ b/tests/Integration/Admin/OAuthTest.php
@@ -20,6 +20,8 @@ use Cloudinary\Test\Integration\IntegrationTestCase;
  */
 final class OAuthTest extends IntegrationTestCase
 {
+    const FAKE_OAUTH_TOKEN = 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4';
+
     private static $UNIQUE_IMAGE_PUBLIC_ID;
 
     public static function setUpBeforeClass()
@@ -31,12 +33,12 @@ final class OAuthTest extends IntegrationTestCase
 
     public function testOAuthToken()
     {
-        $config = ConfigUtils::parseCloudinaryUrl(getenv(Configuration::CLOUDINARY_URL_ENV_VAR));
-        $config = array_merge_recursive(['cloud' => ['oauth_token' => 'not_a_real_token']], $config);
+        $config = new Configuration(Configuration::instance());
+        $config->cloud->oauthToken(self::FAKE_OAUTH_TOKEN);
         $adminApi = new AdminApi($config);
 
         $this->expectExceptionMessage('Invalid token');
 
-        $adminApi->asset(self::$UNIQUE_IMAGE_PUBLIC_ID, ['oauth_token' => 'not_a_real_token']);
+        $adminApi->asset(self::$UNIQUE_IMAGE_PUBLIC_ID);
     }
 }

--- a/tests/Unit/Configuration/ConfigurationTest.php
+++ b/tests/Unit/Configuration/ConfigurationTest.php
@@ -18,6 +18,8 @@ use Cloudinary\Test\Unit\UnitTestCase;
  */
 class ConfigurationTest extends UnitTestCase
 {
+    const OAUTH_TOKEN = 'NTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZj17';
+    const URL_WITH_OAUTH_TOKEN = 'cloudinary://' . self::CLOUD_NAME . '?cloud[oauth_token]=' . self::OAUTH_TOKEN;
 
     public function testConfigFromUrl()
     {
@@ -41,6 +43,26 @@ class ConfigurationTest extends UnitTestCase
         self::assertEquals(self::API_SECRET, $config->cloud->apiSecret);
     }
 
+    public function testConfigFromUrlsWithoutKeyAndSecretButWithOAuthToken()
+    {
+        $config = new Configuration(self::URL_WITH_OAUTH_TOKEN);
+
+        self::assertEquals(self::CLOUD_NAME, $config->cloud->cloudName);
+        self::assertEquals(self::OAUTH_TOKEN, $config->cloud->oauthToken);
+        self::assertNull($config->cloud->apiKey);
+        self::assertNull($config->cloud->apiSecret);
+    }
+
+    public function testConfigFromUrlsWitKeyAndSecretAndOAuthToken()
+    {
+        $config = new Configuration($this->cloudinaryUrl . '?cloud[oauth_token]=' . self::OAUTH_TOKEN);
+
+        self::assertEquals(self::CLOUD_NAME, $config->cloud->cloudName);
+        self::assertEquals(self::API_KEY, $config->cloud->apiKey);
+        self::assertEquals(self::API_SECRET, $config->cloud->apiSecret);
+        self::assertEquals(self::OAUTH_TOKEN, $config->cloud->oauthToken);
+    }
+
     public function testConfigNoEnv()
     {
         self::clearEnvironment();
@@ -61,6 +83,35 @@ class ConfigurationTest extends UnitTestCase
 
         self::assertStrEquals(
             $this->cloudinaryUrl . '/my_distribution?url[cname]=my.domain.com',
+            $config
+        );
+    }
+
+    public function testConfigToStringWithOAuthToken()
+    {
+        $config = Configuration::fromCloudinaryUrl($this->cloudinaryUrl);
+
+        $config->cloud->oauthToken = self::OAUTH_TOKEN;
+
+        self::assertStrEquals(
+            $this->cloudinaryUrl . '?cloud[oauth_token]=' . self::OAUTH_TOKEN,
+            $config
+        );
+    }
+
+    public function testConfigToStringWithMultipleQueryParams()
+    {
+        $config = Configuration::fromCloudinaryUrl($this->cloudinaryUrl);
+
+        $config->url->secureCname = 'my_another_distribution';
+        $config->url->cname       = 'my.another-domain.com';
+
+        $config->cloud->oauthToken = self::OAUTH_TOKEN;
+
+        self::assertStrEquals(
+            $this->cloudinaryUrl . '/my_another_distribution' .
+                '?cloud[oauth_token]=' . self::OAUTH_TOKEN .
+                '&url[cname]=my.another-domain.com',
             $config
         );
     }


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->
Add possibility to use oauth token for authentication instead of api key and secret


#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
