### PR TITLE
Delete unimplemented tests for updating asset's access mode

### DIFF
--- a/tests/Integration/Admin/AssetsTest.php
+++ b/tests/Integration/Admin/AssetsTest.php
@@ -556,30 +556,6 @@ final class AssetsTest extends IntegrationTestCase
     }
 
     /**
-     * Update the access mode of uploaded images by public IDs
-     */
-    public function testUpdateAssetsAccessModeByPublicId()
-    {
-        self::markTestIncomplete('updateAssetsAccessMode not implemented yet');
-    }
-
-    /**
-     * Update the access mode of uploaded images by prefix
-     */
-    public function testUpdateAssetsAccessModeByPrefix()
-    {
-        self::markTestIncomplete('updateAssetsAccessMode not implemented yet');
-    }
-
-    /**
-     * Update the access mode of uploaded images by tag
-     */
-    public function testUpdateAssetsAccessModeByTag()
-    {
-        self::markTestIncomplete('updateAssetsAccessMode not implemented yet');
-    }
-
-    /**
      * Delete uploaded images by a single public ID given as a string
      *
      * @throws ApiError


### PR DESCRIPTION
### Brief Summary of Changes
Delete the unimplemented tests for updating the access mode of uploaded images using [deprecated functionality](https://github.com/cloudinary/cloudinary_php/pull/169#issuecomment-491745223) that wasn't implemented in the new PHP SDK.

#### What does this PR address?
- [x] Remove tests

#### Are tests included?
- [x] Less than before

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
