### PR TITLE
Fix `LoggerTest` class to work in PHP 8

### DIFF
--- a/tests/Unit/Logger/LoggerTest.php
+++ b/tests/Unit/Logger/LoggerTest.php
@@ -12,6 +12,7 @@ namespace Cloudinary\Test\Unit\Logger;
 
 use Cloudinary\Test\Unit\TestHelpers\TestLogger;
 use Cloudinary\Test\Unit\UnitTestCase;
+use Exception;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
@@ -70,8 +71,8 @@ final class LoggerTest extends UnitTestCase
                         'level' => 'ERROR'
                     ]
                 ],
-                'handlersCount' => 3,
-                'handlersContainsInstances' => [
+                'expectedCount' => 3,
+                'expectContainClasses' => [
                     ErrorLogHandler::class,
                     StreamHandler::class
                 ],
@@ -82,8 +83,8 @@ final class LoggerTest extends UnitTestCase
                         'level' => 'ERROR'
                     ]
                 ],
-                'handlersCount' => 1,
-                'handlersContainsInstances' => [
+                'expectedCount' => 1,
+                'expectContainClasses' => [
                     ErrorLogHandler::class,
                 ],
             ],
@@ -91,8 +92,8 @@ final class LoggerTest extends UnitTestCase
                 'config' => [
                     'error_log' => true,
                 ],
-                'handlersCount' => 1,
-                'handlersContainsInstances' => [
+                'expectedCount' => 1,
+                'expectContainClasses' => [
                     ErrorLogHandler::class,
                 ],
             ],
@@ -100,29 +101,29 @@ final class LoggerTest extends UnitTestCase
                 'config' => [
                     'error_log' => false,
                 ],
-                'handlersCount' => 1,
-                'handlersContainsInstances' => [
+                'expectedCount' => 1,
+                'expectContainClasses' => [
                     NullHandler::class,
                 ],
             ],
             [
                 'config' => [],
-                'handlersCount' => 1,
-                'handlersContainsInstances' => [
+                'expectedCount' => 1,
+                'expectContainClasses' => [
                     ErrorLogHandler::class,
                 ],
             ],
             [
                 'config' => ['error_log' => []],
-                'handlersCount' => 1,
-                'handlersContainsInstances' => [
+                'expectedCount' => 1,
+                'expectContainClasses' => [
                     ErrorLogHandler::class,
                 ],
             ],
             [
                 'config' => ['enabled' => false,],
-                'handlersCount' => 0,
-                'handlersContainsInstances' => [],
+                'expectedCount' => 0,
+                'expectContainClasses' => [],
             ],
 
         ];
@@ -158,7 +159,7 @@ final class LoggerTest extends UnitTestCase
 
         try {
             $logger->generateLog();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $exceptionsCaught++;
         }
 
@@ -168,7 +169,7 @@ final class LoggerTest extends UnitTestCase
 
         try {
             $logger->generateLog();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $exceptionsCaught++;
         }
 


### PR DESCRIPTION
### Brief Summary of Changes

Fix `Logger` testing to also work in PHP 8

#### What does this PR address?
- [x] Bug fix

#### Are tests included?
- [x] Yes


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
