### PR TITLE
Add `ValueError` class. Fix `fopen` error in PHP 8

### DIFF
--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -210,7 +210,6 @@ class ApiClient extends BaseApiClient
      * @return PromiseInterface
      *
      * @throws ApiError
-     * @throws Exception
      *
      * @internal
      */
@@ -224,7 +223,7 @@ class ApiClient extends BaseApiClient
 
         try {
             $fileHandle = FileUtils::handleFile($file);
-        } catch (GeneralError $e) {
+        } catch (ApiError $e) {
             $this->getLogger()->critical(
                 'Error while attempting to upload a file',
                 [

--- a/src/Api/Exception/ValueError.php
+++ b/src/Api/Exception/ValueError.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Cloudinary PHP package.
+ *
+ * (c) Cloudinary
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cloudinary\Api\Exception;
+
+/**
+ * Value error.
+ *
+ * @api
+ */
+class ValueError extends ApiError
+{
+}

--- a/src/Utils/FileUtils.php
+++ b/src/Utils/FileUtils.php
@@ -131,6 +131,10 @@ class FileUtils
      */
     public static function safeFileOpen($filename, $mode, $useIncludePath = null)
     {
+        if (empty($filename)) {
+            throw new GeneralError('Filename cannot be empty');
+        }
+
         $fp = @fopen($filename, $mode, $useIncludePath);
 
         if (! $fp) {

--- a/src/Utils/FileUtils.php
+++ b/src/Utils/FileUtils.php
@@ -11,6 +11,7 @@
 namespace Cloudinary;
 
 use Cloudinary\Api\Exception\GeneralError;
+use Cloudinary\Api\Exception\ValueError;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -125,14 +126,14 @@ class FileUtils
      *
      * @return resource
      *
-     * @throws GeneralError
+     * @throws GeneralError|ValueError
      *
      * @see fopen
      */
     public static function safeFileOpen($filename, $mode, $useIncludePath = null)
     {
         if (empty($filename)) {
-            throw new GeneralError('Filename cannot be empty');
+            throw new ValueError('Filename cannot be empty');
         }
 
         $fp = @fopen($filename, $mode, $useIncludePath);
@@ -152,7 +153,7 @@ class FileUtils
      *
      * @return UriInterface|StreamInterface
      *
-     * @throws GeneralError
+     * @throws GeneralError|ValueError
      *
      * @internal
      */

--- a/tests/Unit/ApiClientTest.php
+++ b/tests/Unit/ApiClientTest.php
@@ -27,7 +27,6 @@ final class ApiClientTest extends UnitTestCase
      * Test that attempting to upload a non-existent file logs an error and throws an exception
      *
      * @throws ReflectionException
-     * @throws ApiError
      */
     public function testLoggingPostFileAsyncEmptyFilename()
     {

--- a/tests/Unit/ApiClientTest.php
+++ b/tests/Unit/ApiClientTest.php
@@ -35,7 +35,7 @@ final class ApiClientTest extends UnitTestCase
 
         $message = null;
         $expectedLogMessage = 'Error while attempting to upload a file';
-        $expectedExceptionMessage = 'fopen(): Filename cannot be empty';
+        $expectedExceptionMessage = 'Filename cannot be empty';
         try {
             $apiClient->postFileAsync('/', '', []);
         } catch (Exception $e) {


### PR DESCRIPTION
### Brief Summary of Changes

When `fopen` is called without a parameter in PHP 8 an exception is thrown. This PR introduces a new type of error (`ValueError`) and throws that instead.


#### What does this PR address?
- [x] Bug fix

#### Are tests included?
- [x] Yes

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
