### PR TITLE
Fix support of `resource_type` in `privateDownloadUrl`

### DIFF
--- a/src/Api/Upload/ArchiveTrait.php
+++ b/src/Api/Upload/ArchiveTrait.php
@@ -228,7 +228,9 @@ trait ArchiveTrait
 
         ApiUtils::signRequest($params, $this->getCloud());
 
-        return $this->getUploadUrl(AssetType::IMAGE, UploadEndPoint::DOWNLOAD, $params);
+        $assetType = ArrayUtils::get($options, AssetType::KEY, AssetType::IMAGE);
+
+        return $this->getUploadUrl($assetType, UploadEndPoint::DOWNLOAD, $params);
     }
 
     /**

--- a/tests/Unit/Archive/ArchiveTest.php
+++ b/tests/Unit/Archive/ArchiveTest.php
@@ -62,7 +62,7 @@ class ArchiveTest extends AssetTestCase
         $attachmentName = 'my_attachment_name';
         $expirationTime = time() + 60;
 
-        $url            = self::$uploadApi->privateDownloadUrl(
+        $url = self::$uploadApi->privateDownloadUrl(
             self::ASSET_ID,
             self::IMG_EXT,
             [
@@ -72,7 +72,7 @@ class ArchiveTest extends AssetTestCase
             ]
         );
 
-        $expectedParts  = [
+        $expectedParts = [
             AssetType::IMAGE . '/' . UploadEndPoint::DOWNLOAD,
             'public_id=' . self::ASSET_ID,
             'format=' . self::IMG_EXT,
@@ -87,5 +87,18 @@ class ArchiveTest extends AssetTestCase
         foreach ($expectedParts as $expectedPart) {
             self::assertContains($expectedPart, $url);
         }
+    }
+
+    public function testPrivateDownloadUrlAssetType()
+    {
+        $videoUrl = self::$uploadApi->privateDownloadUrl(
+            self::ASSET_ID,
+            self::VID_EXT,
+            [
+                'resource_type' => AssetType::VIDEO,
+            ]
+        );
+
+        self::assertContains(AssetType::VIDEO . '/' . UploadEndPoint::DOWNLOAD, $videoUrl);
     }
 }


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
