### PR TITLE
Resolving guzzlehttp\psr7 depcrecation errors caused by 2.0.0 release

### DIFF
--- a/src/Utils/FileUtils.php
+++ b/src/Utils/FileUtils.php
@@ -14,7 +14,7 @@ use Cloudinary\Api\Exception\GeneralError;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7;
 
 /**
  * Class Utils
@@ -160,11 +160,11 @@ class FileUtils
         }
 
         if (self::isBase64Data($file)) {
-            $file = stream_for($file);
+            $file = Psr7\Utils::streamFor($file);
         } elseif (is_string($file)) {
             $file = self::safeFileOpen($file, 'rb');
         }
 
-        return stream_for($file);
+        return Psr7\Utils::streamFor($file);
     }
 }

--- a/tests/Integration/Upload/UploadApiTest.php
+++ b/tests/Integration/Upload/UploadApiTest.php
@@ -25,7 +25,7 @@ use Cloudinary\Transformation\Resize;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit_Framework_Constraint_IsType as IsType;
 use Psr\Http\Message\StreamInterface;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7;
 
 /**
  * Class UploadApiTest
@@ -297,7 +297,7 @@ final class UploadApiTest extends IntegrationTestCase
                 "\xFC\x00\x00\x00\x00\x00\x00\x00\x00fff\xFC\x00\x00\x00\x00\x00\x00\x00\x00\xC4\xF5(\xFF\x00\x00\x00" .
                 "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
-        $largeStream = stream_for($head . str_repeat("\xFF", self::LARGE_TEST_IMAGE_SIZE - strlen($head)));
+        $largeStream = Psr7\Utils::streamFor($head . str_repeat("\xFF", self::LARGE_TEST_IMAGE_SIZE - strlen($head)));
         $largeStream->rewind();
 
         return $largeStream;


### PR DESCRIPTION
### Brief Summary of Changes
Implementation unchanged, but new installations will get [guzzlehttp/psr7](https://github.com/guzzle/psr7/) `2.0.0` which was released yesterday, and removed a method that this library relied on.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all of the tests pass.
