### PR TITLE
Fix `GuzzleHttp\Psr7` deprecation errors

### DIFF
--- a/tests/Helpers/RequestAssertionsTrait.php
+++ b/tests/Helpers/RequestAssertionsTrait.php
@@ -14,7 +14,7 @@ use Cloudinary\Api\ApiClient;
 use Cloudinary\Configuration\Configuration;
 use Psr\Http\Message\RequestInterface;
 
-use function GuzzleHttp\Psr7\parse_query;
+use GuzzleHttp\Psr7;
 
 /**
  * Trait RequestAssertionsTrait
@@ -101,7 +101,7 @@ trait RequestAssertionsTrait
     {
         self::assertArraySubset(
             $fields,
-            parse_query($request->getUri()->getQuery()),
+            Psr7\Query::parse($request->getUri()->getQuery()),
             $message ?: 'The expected fields and values were not found in the request query string'
         );
     }
@@ -117,7 +117,7 @@ trait RequestAssertionsTrait
     {
         self::assertArraySubset(
             $fields,
-            parse_query($request->getBody()->getContents()),
+            Psr7\Query::parse($request->getBody()->getContents()),
             $message ?: 'The expected fields and values were not found in the request body'
         );
     }


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
