### PR TITLE
Add tests for upload request parameters demonstrating bug

### DIFF
--- a/tests/CloudinaryTestCase.php
+++ b/tests/CloudinaryTestCase.php
@@ -11,6 +11,7 @@
 namespace Cloudinary\Test;
 
 use Cloudinary\Cloudinary;
+use Cloudinary\Test\Unit\Asset\AssetTestCase;
 use Exception;
 use Monolog\Handler\TestHandler;
 use PHPUnit\Framework\TestCase;
@@ -33,6 +34,8 @@ if (! defined('JSON_INVALID_UTF8_SUBSTITUTE')) {
 abstract class CloudinaryTestCase extends TestCase
 {
     const TEST_BASE64_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+    const TEST_ASSETS_DIR   = __DIR__ . '/assets/';
+    const TEST_IMAGE_PATH   = self::TEST_ASSETS_DIR . AssetTestCase::IMAGE_NAME;
 
     protected static $SUFFIX;
     protected static $TEST_TAG;

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -36,8 +36,6 @@ use Teapot\StatusCode;
  */
 abstract class IntegrationTestCase extends CloudinaryTestCase
 {
-    const TEST_ASSETS_DIR     = __DIR__ . '/../assets/';
-    const TEST_IMAGE_PATH     = self::TEST_ASSETS_DIR . AssetTestCase::IMAGE_NAME;
     const TEST_IMAGE_GIF_PATH = self::TEST_ASSETS_DIR . AssetTestCase::IMAGE_NAME_GIF;
     const TEST_DOCX_PATH      = self::TEST_ASSETS_DIR . AssetTestCase::DOCX_NAME;
     const TEST_VIDEO_PATH     = self::TEST_ASSETS_DIR . AssetTestCase::VIDEO_NAME;

--- a/tests/Unit/Upload/UploadApiTest.php
+++ b/tests/Unit/Upload/UploadApiTest.php
@@ -61,4 +61,53 @@ final class UploadApiTest extends AssetTestCase
         self::assertContains('asset_id', $url);
         self::assertContains('version_id', $url);
     }
+
+    /**
+     * Data provider for `testUploadRequestHeaderParameters()`.
+     *
+     * @return array
+     */
+    public function uploadRequestHeaderParametersDataProvider()
+    {
+        return [
+            'Should support headers as strings' => [
+                'file'    => self::TEST_IMAGE_PATH,
+                'options' => [
+                    'headers' => ['Link: 1', 'X-Robots-Tag: noindex'],
+                ],
+                'result'  => ['Link' => ['1'], 'X-Robots-Tag' => ['noindex']],
+            ],
+
+            'Should support headers as arrays' => [
+                'file'    => self::TEST_IMAGE_PATH,
+                'options' => [
+                    'headers' => ['Link' => '1', 'X-Robots-Tag' => 'noindex'],
+                ],
+                'result'  => ['Link' => ['1'], 'X-Robots-Tag' => ['noindex']],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider uploadRequestHeaderParametersDataProvider
+     *
+     * Checks `upload` request headers parameters.
+     *
+     * @param string $file
+     * @param array  $options
+     * @param array  $result
+     *
+     * @throws ApiError
+     */
+    public function testUploadRequestHeaderParameters($file, $options, $result)
+    {
+        $mockUploadApi = new MockUploadApi();
+        $mockUploadApi->upload($file, $options);
+        $lastRequest = $mockUploadApi->getMockHandler()->getLastRequest();
+
+        self::assertArraySubset(
+            $result,
+            $lastRequest->getHeaders()
+        );
+    }
 }


### PR DESCRIPTION
❗ This PR should not be merged as-is. It adds a couple of tests (including a breaking one) to demonstrate a potential bug.

### Bug description:

The [documentation](https://cloudinary.com/documentation/image_upload_api_reference#upload_optional_parameters) for passing `headers` in the Upload API's `options` states that it accepts a string or possibly an array of strings.

![](https://user-images.githubusercontent.com/1785648/127438821-31873bf7-17eb-4dcb-b299-1f13fe68d195.jpg)

It even gives an example of a possible value: `X-Robots-Tag: noindex`.

The SDK however only accepts the headers as arrays and not as a string.

In other words, this works: 
````php
$api->upload($file, ['headers' => ['Link' => '1', 'X-Robots-Tag' => 'noindex']]);
````

This doesn't work:
````php
$api->upload($file, ['headers' => ['Link: 1', 'X-Robots-Tag: noindex']]);
````

---

Note that the test for [ApiUtils::serializeHeaders()](https://github.com/cloudinary/cloudinary_php/blob/d70503c0f8d627c573171c63c2d6ad64a84d1ab2/tests/Unit/Utils/ApiUtilsTest.php#L67) demonstrates exactly how both **should** be supported.