### PR TITLE
Fix traits that rely on a specific class

### DIFF
--- a/src/Transformation/Rotation/Angle.php
+++ b/src/Transformation/Rotation/Angle.php
@@ -13,13 +13,14 @@ namespace Cloudinary\Transformation;
 use Cloudinary\ArrayUtils;
 use Cloudinary\Transformation\Argument\AngleTrait;
 use Cloudinary\Transformation\Argument\Degree;
+use Cloudinary\Transformation\Argument\RotationMode;
 use Cloudinary\Transformation\Argument\RotationModeTrait;
 use Cloudinary\Transformation\Qualifier\BaseQualifier;
 
 /**
  * Class Angle
  */
-class Angle extends BaseQualifier implements RotationDegreeInterface
+class Angle extends BaseQualifier implements RotationDegreeInterface, RotationModeInterface
 {
     const VALUE_CLASS = Degree::class;
 
@@ -58,5 +59,19 @@ class Angle extends BaseQualifier implements RotationDegreeInterface
     public static function createWithDegree(...$degree)
     {
         return new self(...$degree);
+    }
+
+    /**
+     * Creates the instance.
+     *
+     * @param string|RotationMode|array $mode Given mode.
+     *
+     * @return Angle
+     *
+     * @internal
+     */
+    public static function createWithMode(...$mode)
+    {
+        return new self(...$mode);
     }
 }

--- a/src/Transformation/Rotation/Angle.php
+++ b/src/Transformation/Rotation/Angle.php
@@ -19,7 +19,7 @@ use Cloudinary\Transformation\Qualifier\BaseQualifier;
 /**
  * Class Angle
  */
-class Angle extends BaseQualifier
+class Angle extends BaseQualifier implements RotationDegreeInterface
 {
     const VALUE_CLASS = Degree::class;
 
@@ -44,5 +44,19 @@ class Angle extends BaseQualifier
     public static function fromParams($value)
     {
         return new self(...ArrayUtils::build($value));
+    }
+
+    /**
+     * Creates the instance.
+     *
+     * @param int|array $degree Given degrees or mode.
+     *
+     * @return Angle
+     *
+     * @internal
+     */
+    public static function createWithDegree(...$degree)
+    {
+        return new self(...$degree);
     }
 }

--- a/src/Transformation/Rotation/AngleTrait.php
+++ b/src/Transformation/Rotation/AngleTrait.php
@@ -58,18 +58,4 @@ trait AngleTrait
     {
         return static::createWithDegree(...$degree);
     }
-
-    /**
-     * Creates the instance.
-     *
-     * @param int|array $degree Given degrees or mode.
-     *
-     * @return static
-     *
-     * @internal
-     */
-    protected static function createWithDegree(...$degree)
-    {
-        return new static(...$degree);
-    }
 }

--- a/src/Transformation/Rotation/Degree.php
+++ b/src/Transformation/Rotation/Degree.php
@@ -10,6 +10,7 @@
 
 namespace Cloudinary\Transformation\Argument;
 
+use Cloudinary\Transformation\RotationDegreeInterface;
 use Cloudinary\Transformation\QualifierMultiValue;
 
 /**
@@ -21,7 +22,7 @@ use Cloudinary\Transformation\QualifierMultiValue;
  *
  * @api
  */
-class Degree extends QualifierMultiValue
+class Degree extends QualifierMultiValue implements RotationDegreeInterface
 {
     const VALUE_DELIMITER = '.';
 
@@ -30,4 +31,18 @@ class Degree extends QualifierMultiValue
     const DEG_90          = '90';
     const DEG_180         = '180';
     const DEG_270         = '270';
+
+    /**
+     * Creates the instance.
+     *
+     * @param int|array $degree Given degrees or mode.
+     *
+     * @return Degree
+     *
+     * @internal
+     */
+    public static function createWithDegree(...$degree)
+    {
+        return new self(...$degree);
+    }
 }

--- a/src/Transformation/Rotation/Rotate.php
+++ b/src/Transformation/Rotation/Rotate.php
@@ -28,7 +28,7 @@ use Cloudinary\Transformation\Argument\RotationModeTrait;
  *
  * @api
  */
-class Rotate extends BaseAction
+class Rotate extends BaseAction implements RotationDegreeInterface
 {
     use AngleTrait;
     use RotationModeTrait;
@@ -57,22 +57,10 @@ class Rotate extends BaseAction
      *
      * @param mixed $degree The degree of the angle.
      *
-     * @return static
+     * @return Rotate
      */
-    protected static function createWithDegree(...$degree)
+    public static function createWithDegree(...$degree)
     {
-        return new static(Angle::byAngle(...$degree));
-    }
-
-    /**
-     * Named constructor.
-     *
-     * @param mixed $mode The rotation mode.
-     *
-     * @return static
-     */
-    protected static function createWithMode(...$mode)
-    {
-        return new static(Angle::mode(...$mode));
+        return new self(Angle::byAngle(...$degree));
     }
 }

--- a/src/Transformation/Rotation/Rotate.php
+++ b/src/Transformation/Rotation/Rotate.php
@@ -28,7 +28,7 @@ use Cloudinary\Transformation\Argument\RotationModeTrait;
  *
  * @api
  */
-class Rotate extends BaseAction implements RotationDegreeInterface
+class Rotate extends BaseAction implements RotationDegreeInterface, RotationModeInterface
 {
     use AngleTrait;
     use RotationModeTrait;
@@ -62,5 +62,17 @@ class Rotate extends BaseAction implements RotationDegreeInterface
     public static function createWithDegree(...$degree)
     {
         return new self(Angle::byAngle(...$degree));
+    }
+
+    /**
+     * Named constructor.
+     *
+     * @param mixed $mode The rotation mode.
+     *
+     * @return Rotate
+     */
+    public static function createWithMode(...$mode)
+    {
+        return new self(Angle::mode(...$mode));
     }
 }

--- a/src/Transformation/Rotation/RotationDegreeInterface.php
+++ b/src/Transformation/Rotation/RotationDegreeInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the Cloudinary PHP package.
+ *
+ * (c) Cloudinary
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cloudinary\Transformation;
+
+/**
+ * Interface RotationDegreeInterface
+ */
+interface RotationDegreeInterface
+{
+    /**
+     * Creates the instance.
+     *
+     * @param int|array $degree Given degrees or mode.
+     *
+     * @return self
+     *
+     * @internal
+     */
+    public static function createWithDegree(...$degree);
+}

--- a/src/Transformation/Rotation/RotationMode.php
+++ b/src/Transformation/Rotation/RotationMode.php
@@ -11,6 +11,7 @@
 namespace Cloudinary\Transformation\Argument;
 
 use Cloudinary\Transformation\QualifierMultiValue;
+use Cloudinary\Transformation\RotationModeInterface;
 
 /**
  * Defines how to rotate an image.
@@ -21,7 +22,7 @@ use Cloudinary\Transformation\QualifierMultiValue;
  *
  * @api
  */
-class RotationMode extends QualifierMultiValue
+class RotationMode extends QualifierMultiValue implements RotationModeInterface
 {
     const VALUE_DELIMITER = '.';
 
@@ -32,4 +33,18 @@ class RotationMode extends QualifierMultiValue
     const VERTICAL_FLIP   = 'vflip';
     const HORIZONTAL_FLIP = 'hflip';
     const IGNORE          = 'ignore';
+
+    /**
+     * Creates the instance.
+     *
+     * @param string|RotationMode|array $mode Given mode.
+     *
+     * @return RotationMode
+     *
+     * @internal
+     */
+    public static function createWithMode(...$mode)
+    {
+        return new self(...$mode);
+    }
 }

--- a/src/Transformation/Rotation/RotationModeInterface.php
+++ b/src/Transformation/Rotation/RotationModeInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the Cloudinary PHP package.
+ *
+ * (c) Cloudinary
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cloudinary\Transformation;
+
+use Cloudinary\Transformation\Argument\RotationMode;
+
+/**
+ * Interface RotationModeInterface
+ */
+interface RotationModeInterface
+{
+    /**
+     * Creates the instance.
+     *
+     * @param string|RotationMode|array $mode Given mode.
+     *
+     * @return self
+     *
+     * @internal
+     */
+    public static function createWithMode(...$mode);
+}

--- a/src/Transformation/Rotation/RotationModeTrait.php
+++ b/src/Transformation/Rotation/RotationModeTrait.php
@@ -80,18 +80,4 @@ trait RotationModeTrait
     {
         return static::createWithMode(...$mode);
     }
-
-    /**
-     * Creates the instance.
-     *
-     * @param string|RotationMode|array $mode Given mode.
-     *
-     * @return static
-     *
-     * @internal
-     */
-    protected static function createWithMode(...$mode)
-    {
-        return new static(...$mode);
-    }
 }


### PR DESCRIPTION
### Brief Summary of Changes

`AngleTrait` expects all classes that use it to implement their constructor a certain way, but not all of them do.

See  [`AngleTrait::createWithDegree()`](https://github.com/cloudinary/cloudinary_php/blob/c5d13165ac39f673f4a1e6af582c4a9de2eeff23/src/Transformation/Rotation/AngleTrait.php#L71).

This is fixed by removing `createWithDegree()` from the trait and adding it as part of an interface that needs to be implemented by any class that use this trait.
