### PR TITLE
Allow psr/log v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "guzzlehttp/guzzle": "^6|^7",
     "shrikeh/teapot": "^1|^2",
     "ext-json": "*",
-    "monolog/monolog": "*",
-    "psr/log" : "^1"
+    "monolog/monolog": "^1|^2",
+    "psr/log" : "^1|^2|^3"
   },
   "require-dev": {
     "phpunit/phpunit": "^5",


### PR DESCRIPTION
### Brief Summary of Changes
This change allows installing `cloudinary/cloudinary_php` alongside with `psr/log` v2 and v3.
`monolog/monolog` has been limited to `^1|^2` as it's not a good practice to use `*` wildcard.

#### What does this PR address?

- [x] Refactoring

#### Are tests included?
- [x] No

#### Reviewer, please note:

There are no BC breaks as we don't rely strongly on `psr/log` return types.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
