### PR TITLE
Add support for `reorderMetadataFields()` Admin API

### DIFF
--- a/src/Api/Admin/MetadataFieldsTrait.php
+++ b/src/Api/Admin/MetadataFieldsTrait.php
@@ -200,4 +200,23 @@ trait MetadataFieldsTrait
 
         return $this->apiClient->postJson($uri, $params);
     }
+
+    /**
+     * Reorders metadata fields.
+     *
+     * @param string $orderBy   Criteria for the order (one of the fields 'label', 'external_id', 'created_at').
+     * @param string $direction Optional (gets either asc or desc).
+     *
+     * @return ApiResponse
+     */
+    public function reorderMetadataFields($orderBy, $direction = null)
+    {
+        $uri    = [ApiEndPoint::METADATA_FIELDS, 'order'];
+        $params = [
+            'order_by'  => $orderBy,
+            'direction' => $direction,
+        ];
+
+        return $this->apiClient->putJson($uri, $params);
+    }
 }

--- a/tests/Helpers/RequestAssertionsTrait.php
+++ b/tests/Helpers/RequestAssertionsTrait.php
@@ -57,6 +57,17 @@ trait RequestAssertionsTrait
     }
 
     /**
+     * Assert the HTTP request method is PUT.
+     *
+     * @param RequestInterface $request
+     * @param string           $message
+     */
+    protected static function assertRequestPut(RequestInterface $request, $message = 'HTTP method should be PUT')
+    {
+        self::assertEquals('PUT', $request->getMethod(), $message);
+    }
+
+    /**
      * Asserts that a request contains the expected fields and values.
      *
      * @param RequestInterface $request

--- a/tests/Unit/Admin/MetadataFieldsTest.php
+++ b/tests/Unit/Admin/MetadataFieldsTest.php
@@ -160,4 +160,67 @@ class MetadataFieldsTest extends UnitTestCase
         self::assertRequestDelete($lastRequest);
         self::assertRequestFields($lastRequest);
     }
+
+    /**
+     * Test the reorder of metadata fields for label order by asc.
+     */
+    public function testReorderMetadataFieldsByLabel()
+    {
+        $mockAdminApi = new MockAdminApi();
+
+        $mockAdminApi->reorderMetadataFields('label', 'asc');
+        $lastRequest = $mockAdminApi->getMockHandler()->getLastRequest();
+
+        self::assertRequestUrl(
+            $lastRequest,
+            '/metadata_fields/order'
+        );
+        self::assertRequestPut($lastRequest);
+        self::assertRequestJsonBodySubset(
+            $lastRequest,
+            ['order_by' => 'label', 'direction' => 'asc']
+        );
+    }
+
+    /**
+     * Test the reorder of metadata fields for external_id order by desc.
+     */
+    public function testReorderMetadataFieldsByExternalId()
+    {
+        $mockAdminApi = new MockAdminApi();
+
+        $mockAdminApi->reorderMetadataFields('external_id', 'asc');
+        $lastRequest = $mockAdminApi->getMockHandler()->getLastRequest();
+
+        self::assertRequestUrl(
+            $lastRequest,
+            '/metadata_fields/order'
+        );
+        self::assertRequestPut($lastRequest);
+        self::assertRequestJsonBodySubset(
+            $lastRequest,
+            ['order_by' => 'external_id', 'direction' => 'asc']
+        );
+    }
+
+    /**
+     * Test the reorder of metadata fields for created_at order by asc.
+     */
+    public function testReorderMetadataFieldsByCreatedAt()
+    {
+        $mockAdminApi = new MockAdminApi();
+
+        $mockAdminApi->reorderMetadataFields('created_at', 'asc');
+        $lastRequest = $mockAdminApi->getMockHandler()->getLastRequest();
+
+        self::assertRequestUrl(
+            $lastRequest,
+            '/metadata_fields/order'
+        );
+        self::assertRequestPut($lastRequest);
+        self::assertRequestJsonBodySubset(
+            $lastRequest,
+            ['order_by' => 'created_at', 'direction' => 'asc']
+        );
+    }
 }


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
