### PR TITLE
Test on PHP 8.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,34 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  php:
+    name: PHP ${{ matrix.php-versions }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions:
+          - '5.6'
+          - '7.0'
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
+          - '8.0'
+          - '8.1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: json
+          coverage: xdebug
+      - name: Install Composer dependencies
+        run: composer update -n
+      - name: Run Tests
+        run: |
+          export CLOUDINARY_URL=$(bash tools/get_test_cloud.sh);
+          echo cloud_name: "$(echo $CLOUDINARY_URL | cut -d'@' -f2)"
+          vendor/bin/simple-phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tools/dev/sanity/node_modules
 tools/dev/sanity/package-lock.json
 tools/dev/sanity/results.json
 tools/dev/sanity/TransformationSanityTest.php
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - '8.0'
   - '7.4'
   - '7.3'
-  - '7.2'
+  - '7.2.34'
   - '7.1'
   - '7.0'
   - '5.6'
@@ -16,7 +16,7 @@ install: composer install
 before_script: >
   export CLOUDINARY_URL=$(bash tools/get_test_cloud.sh);
   echo cloud_name: "$(echo $CLOUDINARY_URL | cut -d'@' -f2)"
-script: vendor/bin/simple-phpunit
+script: vendor/bin/simple-phpunit -v
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 php:
+  - '8.1'
+  - '8.0'
   - '7.4'
   - '7.3'
   - '7.2'
@@ -14,7 +16,7 @@ install: composer install
 before_script: >
   export CLOUDINARY_URL=$(bash tools/get_test_cloud.sh);
   echo cloud_name: "$(echo $CLOUDINARY_URL | cut -d'@' -f2)"
-script: vendor/bin/phpunit
+script: vendor/bin/simple-phpunit
 
 branches:
   except:

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "psr/log" : "^1|^2|^3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5",
+    "symfony/phpunit-bridge": "^5.2",
     "phpmd/phpmd": "*",
     "squizlabs/php_codesniffer": "3.*",
     "friendsofphp/php-cs-fixer": "*",
@@ -48,11 +48,8 @@
     ]
   },
   "autoload-dev": {
-    "classmap": [
-      "tests"
-    ],
     "psr-4": {
-      "Cloudinary\\Test\\": "tests/"
+      "Cloudinary\\Test\\": "tests"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,8 +11,11 @@
         processIsolation            = "false"
         stopOnFailure               = "false"
         syntaxCheck                 = "false"
+        bootstrap="vendor/autoload.php"
 >
-
+    <php>
+        <server name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1"/>
+    </php>
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit
-        backupGlobals               = "false"
-        backupStaticAttributes      = "false"
-        colors                      = "true"
-        convertErrorsToExceptions   = "true"
-        convertNoticesToExceptions  = "true"
-        convertWarningsToExceptions = "true"
-        processIsolation            = "false"
-        stopOnFailure               = "false"
-        syntaxCheck                 = "false"
-        bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="vendor/autoload.php"
 >
     <php>
-        <server name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1"/>
     </php>
     <testsuites>
         <testsuite name="Unit">
@@ -26,12 +26,8 @@
     </testsuites>
 
     <filter>
-        <blacklist>
-            <directory suffix=".php">./vendor</directory>
-        </blacklist>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
-
 </phpunit>

--- a/src/Asset/AuthToken.php
+++ b/src/Asset/AuthToken.php
@@ -174,7 +174,7 @@ class AuthToken
         $expiration = $this->config->expiration;
         $duration   = $this->config->duration;
 
-        if (! strcasecmp($start, 'now')) {
+        if (! strcasecmp((string) $start, 'now')) {
             $start = Utils::unixTimeNow();
         } elseif (is_numeric($start)) {
             $start = (int)$start;

--- a/tests/Helpers/RequestAssertionsTrait.php
+++ b/tests/Helpers/RequestAssertionsTrait.php
@@ -110,7 +110,7 @@ trait RequestAssertionsTrait
      */
     protected static function assertRequestQueryStringSubset(RequestInterface $request, $fields = null, $message = '')
     {
-        self::assertArraySubset(
+        self::assertSubset(
             $fields,
             Psr7\Query::parse($request->getUri()->getQuery()),
             $message ?: 'The expected fields and values were not found in the request query string'
@@ -126,7 +126,7 @@ trait RequestAssertionsTrait
      */
     protected static function assertRequestBodySubset(RequestInterface $request, $fields = null, $message = '')
     {
-        self::assertArraySubset(
+        self::assertSubset(
             $fields,
             Psr7\Query::parse($request->getBody()->getContents()),
             $message ?: 'The expected fields and values were not found in the request body'
@@ -142,10 +142,9 @@ trait RequestAssertionsTrait
      */
     protected static function assertRequestJsonBodySubset(RequestInterface $request, $fields = null, $message = '')
     {
-        self::assertArraySubset(
+        self::assertSubset(
             $fields,
             json_decode($request->getBody()->getContents(), true),
-            false,
             $message ?: 'The expected fields and values were not found in the request body'
         );
     }
@@ -159,7 +158,7 @@ trait RequestAssertionsTrait
      */
     protected static function assertRequestHeaderSubset(RequestInterface $request, $fields = null, $message = '')
     {
-        self::assertArraySubset(
+        self::assertSubset(
             $fields,
             $request->getHeaders(),
             $message ?: 'The expected fields and values were not found in the request header'

--- a/tests/Integration/Admin/AdaptiveStreamingProfilesTest.php
+++ b/tests/Integration/Admin/AdaptiveStreamingProfilesTest.php
@@ -15,7 +15,7 @@ use Cloudinary\Api\Exception\NotFound;
 use Cloudinary\Test\Integration\IntegrationTestCase;
 use Cloudinary\Transformation\Qualifier;
 use Cloudinary\Transformation\Transformation;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * Class AdaptiveStreamingProfilesTest

--- a/tests/Integration/Admin/FoldersTest.php
+++ b/tests/Integration/Admin/FoldersTest.php
@@ -14,7 +14,7 @@ use Cloudinary\Api\ApiResponse;
 use Cloudinary\Api\Exception\ApiError;
 use Cloudinary\Api\Exception\NotFound;
 use Cloudinary\Test\Integration\IntegrationTestCase;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * Class FoldersTest

--- a/tests/Integration/Admin/MetadataFieldsTest.php
+++ b/tests/Integration/Admin/MetadataFieldsTest.php
@@ -28,7 +28,7 @@ use Cloudinary\Test\Integration\IntegrationTestCase;
 use DateInterval;
 use DateTime;
 use Exception;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * Class MetadataFieldsTest
@@ -132,7 +132,7 @@ class MetadataFieldsTest extends IntegrationTestCase
      */
     private static function assertMetadataField($metadataField, $type = null, $values = [])
     {
-        self::assertInternalType(IsType::TYPE_STRING, $metadataField['external_id']);
+        self::assertIsString($metadataField['external_id']);
         if ($type) {
             self::assertEquals($type, $metadataField['type']);
         } else {
@@ -147,8 +147,8 @@ class MetadataFieldsTest extends IntegrationTestCase
                 ]
             );
         }
-        self::assertInternalType(IsType::TYPE_STRING, $metadataField['label']);
-        self::assertInternalType(IsType::TYPE_BOOL, $metadataField['mandatory']);
+        self::assertIsString($metadataField['label']);
+        self::assertIsBool($metadataField['mandatory']);
         self::assertArrayHasKey('default_value', (array)$metadataField);
         self::assertArrayHasKey('validation', (array)$metadataField);
         if (in_array($metadataField['type'], [MetadataFieldType::ENUM, MetadataFieldType::SET], true)) {
@@ -172,8 +172,8 @@ class MetadataFieldsTest extends IntegrationTestCase
         self::assertNotEmpty($dataSource);
         self::assertArrayHasKey('values', $dataSource);
         if (!empty($dataSource['values'])) {
-            self::assertInternalType(IsType::TYPE_STRING, $dataSource['values'][0]['value']);
-            self::assertInternalType(IsType::TYPE_STRING, $dataSource['values'][0]['external_id']);
+            self::assertIsString($dataSource['values'][0]['value']);
+            self::assertIsString($dataSource['values'][0]['external_id']);
             if (!empty($dataSource['values'][0]['state'])) {
                 self::assertContains($dataSource['values'][0]['state'], ['active', 'inactive']);
             }

--- a/tests/Integration/Admin/TagsTest.php
+++ b/tests/Integration/Admin/TagsTest.php
@@ -12,7 +12,7 @@ namespace Cloudinary\Test\Integration\Admin;
 
 use Cloudinary\Api\Exception\ApiError;
 use Cloudinary\Test\Integration\IntegrationTestCase;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * Class TagsTest
@@ -59,7 +59,7 @@ final class TagsTest extends IntegrationTestCase
 
         self::assertObjectStructure($result, ['tags' => IsType::TYPE_ARRAY]);
         self::assertCount(2, $result['tags']);
-        self::assertInternalType(IsType::TYPE_STRING, $result['tags'][0]);
+        self::assertIsString($result['tags'][0]);
     }
 
     /**

--- a/tests/Integration/Admin/UsageTest.php
+++ b/tests/Integration/Admin/UsageTest.php
@@ -12,7 +12,7 @@ namespace Cloudinary\Test\Integration\Admin;
 
 use Cloudinary\Api\Exception\ApiError;
 use Cloudinary\Test\Integration\IntegrationTestCase;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * Class UsageTest

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -27,7 +27,7 @@ use Cloudinary\Test\Unit\Asset\AssetTestCase;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 use ReflectionClass;
 use RuntimeException;
 use Teapot\StatusCode;
@@ -444,7 +444,7 @@ abstract class IntegrationTestCase extends CloudinaryTestCase
                 'file_count'     => IsType::TYPE_INT,
             ]
         );
-        self::assertRegexp('/\.' . $format . '$/', $archive['url']);
+        self::assertMatchesRegularExpression('/\.' . $format . '$/', $archive['url']);
     }
 
     /**
@@ -635,8 +635,9 @@ abstract class IntegrationTestCase extends CloudinaryTestCase
         if ($path) {
             self::assertEquals($path, $parseUrl['path']);
         }
-        if (! empty($values)) {
-            self::assertArraySubset($values, $query);
+
+        foreach ($values as $key => $value) {
+            self::assertSame($value, $query[$key]);
         }
     }
 

--- a/tests/Integration/Provisioning/ProvisioningIntegrationTestCase.php
+++ b/tests/Integration/Provisioning/ProvisioningIntegrationTestCase.php
@@ -14,7 +14,7 @@ use Cloudinary\Api\Provisioning\AccountApi;
 use Cloudinary\Exception\ConfigurationException;
 use Cloudinary\Test\CloudinaryTestCase;
 use Exception;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 use RuntimeException;
 
 /**
@@ -156,7 +156,7 @@ abstract class ProvisioningIntegrationTestCase extends CloudinaryTestCase
         }
 
         if (isset($user['sub_account_ids'])) {
-            self::assertInternalType(IsType::TYPE_STRING, $user['sub_account_ids']);
+            self::assertIsString($user['sub_account_ids']);
         }
 
         foreach ($values as $key => $value) {

--- a/tests/Integration/Upload/CreativeTest.php
+++ b/tests/Integration/Upload/CreativeTest.php
@@ -19,7 +19,7 @@ use Cloudinary\Configuration\Configuration;
 use Cloudinary\Test\Integration\IntegrationTestCase;
 use Cloudinary\Transformation\Extract;
 use Cloudinary\Transformation\Transformation;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * Class CreativeTest
@@ -114,7 +114,7 @@ final class CreativeTest extends IntegrationTestCase
         self::addAssetToCleanupList($asset, [DeliveryType::KEY => DeliveryType::SPRITE]);
 
         self::assertValidSprite($asset);
-        self::assertContains('w_100', $asset['css_url']);
+        self::assertStringContainsString('w_100', $asset['css_url']);
 
         $asset = self::$uploadApi->generateSprite(
             self::$TAG_TO_GENERATE_SPRITE,
@@ -126,7 +126,7 @@ final class CreativeTest extends IntegrationTestCase
         self::addAssetToCleanupList($asset, [DeliveryType::KEY => DeliveryType::SPRITE]);
 
         self::assertValidSprite($asset);
-        self::assertContains('w_100/f_jpg', $asset['css_url']);
+        self::assertStringContainsString('w_100/f_jpg', $asset['css_url']);
     }
 
     /**
@@ -187,7 +187,7 @@ final class CreativeTest extends IntegrationTestCase
 
         self::assertValidMulti($asset);
         self::assertStringEndsWith('.gif', $asset['url']);
-        self::assertContains('w_0.5', $asset['url']);
+        self::assertStringContainsString('w_0.5', $asset['url']);
 
         $asset = self::$uploadApi->multi(
             self::$TAG_TO_MULTI,
@@ -199,7 +199,7 @@ final class CreativeTest extends IntegrationTestCase
 
         self::assertValidMulti($asset);
         self::assertStringEndsWith('.gif', $asset['url']);
-        self::assertContains('w_0.5', $asset['url']);
+        self::assertStringContainsString('w_0.5', $asset['url']);
 
         $asset = self::$uploadApi->multi(
             self::$TAG_TO_MULTI,
@@ -212,7 +212,7 @@ final class CreativeTest extends IntegrationTestCase
 
         self::assertValidMulti($asset);
         self::assertStringEndsWith('.pdf', $asset['url']);
-        self::assertContains('w_111', $asset['url']);
+        self::assertStringContainsString('w_111', $asset['url']);
     }
 
     /**

--- a/tests/Integration/Upload/UploadApiTest.php
+++ b/tests/Integration/Upload/UploadApiTest.php
@@ -23,7 +23,7 @@ use Cloudinary\Test\Unit\Asset\AssetTestCase;
 use Cloudinary\Transformation\Format;
 use Cloudinary\Transformation\Resize;
 use GuzzleHttp\Psr7\Uri;
-use PHPUnit_Framework_Constraint_IsType as IsType;
+use PHPUnit\Framework\Constraint\IsType;
 use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Psr7;
 
@@ -489,8 +489,8 @@ final class UploadApiTest extends IntegrationTestCase
                         'context' => ['custom' => ['width' => self::TEST_IMAGE_WIDTH]],
                     ]
                 );
-                self::assertInternalType(IsType::TYPE_ARRAY, $result['quality_analysis']);
-                self::assertInternalType(IsType::TYPE_NUMERIC, $result['quality_analysis']['focus']);
+                self::assertIsArray($result['quality_analysis']);
+                self::assertIsNumeric($result['quality_analysis']['focus']);
             },
             3,
             1,
@@ -525,8 +525,8 @@ final class UploadApiTest extends IntegrationTestCase
         self::assertValidAsset($asset);
         self::assertArrayHasKey('responsive_breakpoints', $asset);
         self::assertEquals('a_90', $asset['responsive_breakpoints'][0]['transformation']);
-        self::assertRegExp('/\.gif$/', $asset['responsive_breakpoints'][0]['breakpoints'][0]['url']);
-        self::assertRegExp('/\.gif$/', $asset['responsive_breakpoints'][0]['breakpoints'][0]['secure_url']);
+        self::assertMatchesRegularExpression('/\.gif$/', $asset['responsive_breakpoints'][0]['breakpoints'][0]['url']);
+        self::assertMatchesRegularExpression('/\.gif$/', $asset['responsive_breakpoints'][0]['breakpoints'][0]['secure_url']);
     }
 
     /**

--- a/tests/Unit/Archive/ArchiveTest.php
+++ b/tests/Unit/Archive/ArchiveTest.php
@@ -38,23 +38,23 @@ class ArchiveTest extends AssetTestCase
     {
         // should return url with resource_type image.
         $url = self::$uploadApi->downloadFolder('samples/', ['resource_type' => AssetType::IMAGE]);
-        self::assertContains('image', $url);
+        self::assertStringContainsString('image', $url);
 
         // should return valid url.
         $url = self::$uploadApi->downloadFolder('folder/');
-        self::assertContains('generate_archive', $url);
+        self::assertStringContainsString('generate_archive', $url);
 
         // should flatten folder.
         $url = self::$uploadApi->downloadFolder('folder/', ['flatten_folders' => true]);
-        self::assertContains('flatten_folders', $url);
+        self::assertStringContainsString('flatten_folders', $url);
 
         // should expire_at folder.
         $url = self::$uploadApi->downloadFolder('folder/', ['expires_at' => time() + 60]);
-        self::assertContains('expires_at', $url);
+        self::assertStringContainsString('expires_at', $url);
 
         // should use original file_name of folder.
         $url = self::$uploadApi->downloadFolder('folder/', ['use_original_filename' => true]);
-        self::assertContains('use_original_filename', $url);
+        self::assertStringContainsString('use_original_filename', $url);
     }
 
     public function testPrivateDownloadUrl()
@@ -85,7 +85,7 @@ class ArchiveTest extends AssetTestCase
         ];
 
         foreach ($expectedParts as $expectedPart) {
-            self::assertContains($expectedPart, $url);
+            self::assertStringContainsString($expectedPart, $url);
         }
     }
 
@@ -99,6 +99,6 @@ class ArchiveTest extends AssetTestCase
             ]
         );
 
-        self::assertContains(AssetType::VIDEO . '/' . UploadEndPoint::DOWNLOAD, $videoUrl);
+        self::assertStringContainsString(AssetType::VIDEO . '/' . UploadEndPoint::DOWNLOAD, $videoUrl);
     }
 }

--- a/tests/Unit/Asset/AuthTokenTest.php
+++ b/tests/Unit/Asset/AuthTokenTest.php
@@ -49,14 +49,12 @@ class AuthTokenTest extends AuthTokenTestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMustProvideExpirationOrDuration()
     {
         $message                             = 'Should throw if expiration and duration are not provided';
         $this->authToken->config->expiration = null;
         $this->authToken->config->duration   = null;
+        $this->expectException(InvalidArgumentException::class);
         $this->authToken->generate();
         $this->fail($message);
     }

--- a/tests/Unit/Asset/DistributionTest.php
+++ b/tests/Unit/Asset/DistributionTest.php
@@ -249,7 +249,7 @@ final class DistributionTest extends AssetTestCase
 
         $config->url->analytics();
 
-        self::assertContains(
+        self::assertStringContainsString(
             '?' . Analytics::QUERY_KEY . '=',
             (string)new Image(self::ASSET_ID, $config)
         );
@@ -261,7 +261,7 @@ final class DistributionTest extends AssetTestCase
 
         $config->url->analytics();
 
-        self::assertNotContains(
+        self::assertStringNotContainsString(
             '?' . Analytics::QUERY_KEY . '=',
             (string)new Image(self::FETCH_IMAGE_URL_WITH_QUERY, $config)
         );
@@ -276,12 +276,12 @@ final class DistributionTest extends AssetTestCase
 
         $config->url->signUrl()->analytics();
 
-        self::assertNotContains(
+        self::assertStringNotContainsString(
             '?' . Analytics::QUERY_KEY . '=',
             (string)new Image(self::ASSET_ID, $config)
         );
 
-        self::assertContains(
+        self::assertStringContainsString(
             AuthToken::AUTH_TOKEN_NAME,
             (string)new Image(self::ASSET_ID, $config)
         );

--- a/tests/Unit/Asset/MediaFromParamsTest.php
+++ b/tests/Unit/Asset/MediaFromParamsTest.php
@@ -19,6 +19,7 @@ use Cloudinary\Configuration\Configuration;
 use Cloudinary\Configuration\UrlConfig;
 use Cloudinary\Utils;
 use InvalidArgumentException;
+use UnexpectedValueException;
 
 /**
  * Class MediaFromParamsTest
@@ -67,12 +68,11 @@ final class MediaFromParamsTest extends AssetTestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testNoConfigThrowsException()
     {
         self::clearEnvironment();
+
+        $this->expectException(InvalidArgumentException::class);
 
         self::assertMediaFromParamsUrl(
             self::IMAGE_NAME
@@ -563,13 +563,13 @@ final class MediaFromParamsTest extends AssetTestCase
 
     /**
      * Should disallow url_suffix with '.'
-     *
-     * @expectedException \UnexpectedValueException
      */
     public function testDisallowSuffixWithDot()
     {
         //
         $options = ['url_suffix' => 'hello.world', 'private_cdn' => true];
+
+        $this->expectException(UnexpectedValueException::class);
         self::assertMediaFromParamsUrl(
             self::IMAGE_NAME,
             $options
@@ -578,13 +578,12 @@ final class MediaFromParamsTest extends AssetTestCase
 
     /**
      * Should disallow url_suffix with '/'
-     *
-     * @expectedException \UnexpectedValueException
      */
     public function testDisallowSuffixWithSlash()
     {
         $options = ['url_suffix' => 'hello/world', 'private_cdn' => true];
 
+        $this->expectException(UnexpectedValueException::class);
         self::assertMediaFromParamsUrl(
             self::IMAGE_NAME,
             $options

--- a/tests/Unit/Asset/MediaTest.php
+++ b/tests/Unit/Asset/MediaTest.php
@@ -64,11 +64,9 @@ final class MediaTest extends AssetTestCase
         );
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testMediaAssetSuffixValidation()
     {
+        $this->expectException(UnexpectedValueException::class);
         $this->media->suffix('../illegal_suffix.//');
     }
 

--- a/tests/Unit/Cloudinary/CloudinaryTagTest.php
+++ b/tests/Unit/Cloudinary/CloudinaryTagTest.php
@@ -61,7 +61,7 @@ class CloudinaryTagTest extends AssetTestCase
 
         $expectedImage = $this->c->image(self::IMAGE_NAME);
 
-        self::assertContains(self::TEST_HOSTNAME, (string)$expectedImage);
+        self::assertStringContainsString(self::TEST_HOSTNAME, (string)$expectedImage);
 
         self::assertStrEquals(
             '<img src="'.$expectedImage.'">',

--- a/tests/Unit/Cloudinary/CloudinaryTest.php
+++ b/tests/Unit/Cloudinary/CloudinaryTest.php
@@ -29,12 +29,11 @@ class CloudinaryTest extends UnitTestCase
         self::assertNotNull($c->configuration->cloud->apiSecret);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCloudinaryUrlNotSet()
     {
         self::clearEnvironment();
+
+        $this->expectException(InvalidArgumentException::class);
 
         new Cloudinary(); // Boom!
     }

--- a/tests/Unit/Tag/FormTagTest.php
+++ b/tests/Unit/Tag/FormTagTest.php
@@ -41,6 +41,6 @@ final class FormTagTest extends TagTestCase
         $tag = new FormTag($this->configuration, $this->uploadParams);
         $tag->addClass('uploader');
 
-        self::assertRegExp(FormTagPatterns::getFormTagPattern(), (string)$tag);
+        self::assertMatchesRegularExpression(FormTagPatterns::getFormTagPattern(), (string)$tag);
     }
 }

--- a/tests/Unit/Tag/PictureSourceTagTest.php
+++ b/tests/Unit/Tag/PictureSourceTagTest.php
@@ -118,7 +118,7 @@ final class PictureSourceTagTest extends ImageTagTestCase
 
     public function testPictureSourceTagInvalidMedia()
     {
-        self::assertNotContains(
+        self::assertStringNotContainsString(
             'media',
             (new PictureSourceTag($this->src))->media(self::MAX_WIDTH, self::MIN_WIDTH)->toTag()
         );
@@ -126,7 +126,7 @@ final class PictureSourceTagTest extends ImageTagTestCase
 
     public function testPictureSourceTagNoMedia()
     {
-        self::assertNotContains(
+        self::assertStringNotContainsString(
             'media',
             (new PictureSourceTag($this->src))->media()->toTag()
         );

--- a/tests/Unit/Tag/TagFromParamsTest.php
+++ b/tests/Unit/Tag/TagFromParamsTest.php
@@ -818,7 +818,7 @@ final class TagFromParamsTest extends ImageTagTestCase
                    "data-url='http[^']+\/v1_1\/test123\/auto\/upload' " .
                    "name='file' type='file'\/>/";
 
-        self::assertRegExp($pattern, (string)UploadTag::fromParams('image'));
+        self::assertMatchesRegularExpression($pattern, (string)UploadTag::fromParams('image'));
 
         $pattern = "/<input class='cloudinary-fileupload' " .
                    "data-cloudinary-field='image' " .
@@ -827,7 +827,7 @@ final class TagFromParamsTest extends ImageTagTestCase
                    "data-max-chunk-size='5000000' " .
                    "data-url='http[^']+\/v1_1\/test123\/auto\/upload' " .
                    "name='file' type='file'\/>/";
-        self::assertRegExp($pattern, (string)UploadTag::fromParams('image', ['chunk_size' => 5000000]));
+        self::assertMatchesRegularExpression($pattern, (string)UploadTag::fromParams('image', ['chunk_size' => 5000000]));
 
         $pattern = "/<input class='cloudinary-fileupload classy' " .
                    "data-cloudinary-field='image' " .
@@ -836,7 +836,7 @@ final class TagFromParamsTest extends ImageTagTestCase
                    "data-max-chunk-size='\d+' " .
                    "data-url='http[^']+\/v1_1\/test123\/auto\/upload' " .
                    "name='file' type='file'\/>/";
-        self::assertRegExp($pattern, (string)UploadTag::fromParams('image', ['html' => ['class' => 'classy']]));
+        self::assertMatchesRegularExpression($pattern, (string)UploadTag::fromParams('image', ['html' => ['class' => 'classy']]));
     }
 
     /**

--- a/tests/Unit/Tag/UploadTagTest.php
+++ b/tests/Unit/Tag/UploadTagTest.php
@@ -42,7 +42,7 @@ final class UploadTagTest extends TagTestCase
             '\&quot;api_key\&quot;:\&quot;\w+\&quot;}" ' .
             'data-url="http[^\']+\/v1_1\/test123\/auto\/upload"' .
             '>/';
-        self::assertRegExp($pattern, (string)$tag);
+        self::assertMatchesRegularExpression($pattern, (string)$tag);
     }
 
 
@@ -60,7 +60,7 @@ final class UploadTagTest extends TagTestCase
             'data-url="http[^\']+\/v1_1\/test123\/auto\/upload"' .
             '>/';
 
-        self::assertRegExp(
+        self::assertMatchesRegularExpression(
             $pattern,
             (string)$tag
         );
@@ -80,7 +80,7 @@ final class UploadTagTest extends TagTestCase
             '\&quot;api_key\&quot;:\&quot;\w+\&quot;}" ' .
             'data-url="http[^\']+\/v1_1\/test123\/auto\/upload"' .
             '>/';
-        self::assertRegExp(
+        self::assertMatchesRegularExpression(
             $pattern,
             (string)$tag
         );
@@ -98,7 +98,7 @@ final class UploadTagTest extends TagTestCase
             '\&quot;timestamp\&quot;:\d+}" ' .
             'data-url="http[^\']+\/v1_1\/test123\/auto\/upload"' .
             '>/';
-        self::assertRegExp(
+        self::assertMatchesRegularExpression(
             $pattern,
             (string)$tag
         );

--- a/tests/Unit/Upload/OAuthTest.php
+++ b/tests/Unit/Upload/OAuthTest.php
@@ -102,11 +102,9 @@ final class OAuthTest extends AssetTestCase
         $uploadApi = new MockUploadApi($config);
         $uploadApi->unsignedUpload(self::TEST_BASE64_IMAGE, self::API_TEST_PRESET);
 
-        self::assertArraySubset(
-            [
-                'upload_preset' => self::API_TEST_PRESET
-            ],
-            $uploadApi->getApiClient()->getRequestMultipartOptions()
+        self::assertSame(
+            self::API_TEST_PRESET,
+            $uploadApi->getApiClient()->getRequestMultipartOptions()['upload_preset']
         );
     }
 }

--- a/tests/Unit/Upload/UploadApiTest.php
+++ b/tests/Unit/Upload/UploadApiTest.php
@@ -37,7 +37,7 @@ final class UploadApiTest extends AssetTestCase
         $mockUploadApi->upload(self::TEST_BASE64_IMAGE, ['accessibility_analysis' => true]);
         $lastOptions = $mockUploadApi->getApiClient()->getRequestMultipartOptions();
 
-        self::assertArraySubset(['accessibility_analysis' => '1'], $lastOptions);
+        self::assertEquals('1', $lastOptions['accessibility_analysis']);
     }
 
     /**
@@ -62,8 +62,8 @@ final class UploadApiTest extends AssetTestCase
             '0e493356d8a40b856c4863c026891a4e'
         );
 
-        self::assertContains('asset_id', $url);
-        self::assertContains('version_id', $url);
+        self::assertStringContainsString('asset_id', $url);
+        self::assertStringContainsString('version_id', $url);
     }
 
     /**
@@ -77,7 +77,7 @@ final class UploadApiTest extends AssetTestCase
         $mockUploadApi->upload(self::TEST_BASE64_IMAGE);
         $lastOptions = $mockUploadApi->getApiClient()->getRequestOptions();
 
-        self::assertArraySubset(['chunk_size' => ApiConfig::DEFAULT_CHUNK_SIZE], $lastOptions);
+        self::assertSame(ApiConfig::DEFAULT_CHUNK_SIZE, $lastOptions['chunk_size']);
     }
 
     /**
@@ -91,7 +91,7 @@ final class UploadApiTest extends AssetTestCase
         $mockUploadApi->upload(self::TEST_BASE64_IMAGE, ['chunk_size' => self::TEST_CHUNK_SIZE]);
         $lastOptions = $mockUploadApi->getApiClient()->getRequestOptions();
 
-        self::assertArraySubset(['chunk_size' => self::TEST_CHUNK_SIZE], $lastOptions);
+        self::assertSame(self::TEST_CHUNK_SIZE, $lastOptions['chunk_size']);
     }
 
     /**
@@ -107,7 +107,7 @@ final class UploadApiTest extends AssetTestCase
         $mockUploadApi->upload(self::TEST_BASE64_IMAGE);
         $lastOptions = $mockUploadApi->getApiClient()->getRequestOptions();
 
-        self::assertArraySubset(['chunk_size' => self::TEST_CHUNK_SIZE], $lastOptions);
+        self::assertSame(self::TEST_CHUNK_SIZE, $lastOptions['chunk_size']);
     }
 
     /**
@@ -129,6 +129,6 @@ final class UploadApiTest extends AssetTestCase
         $mockUploadApi->upload(self::TEST_BASE64_IMAGE, $options);
         $lastOptions = $mockUploadApi->getApiClient()->getRequestMultipartOptions();
 
-        self::assertArraySubset($options, $lastOptions);
+        self::assertSubset($options, $lastOptions);
     }
 }

--- a/tests/Unit/Utils/SignatureVerifierTest.php
+++ b/tests/Unit/Utils/SignatureVerifierTest.php
@@ -140,13 +140,12 @@ class SignatureVerifierTest extends AssetTestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @expectedException           InvalidArgumentException
-     * @expectedExceptionMessage    API Secret is invalid
-     */
     public function testNotificationMissingApiSecret()
     {
         Configuration::instance()->cloud->apiSecret = null;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('API Secret is invalid');
 
         SignatureVerifier::verifyNotificationSignature(
             self::$notificationBody,
@@ -251,13 +250,12 @@ class SignatureVerifierTest extends AssetTestCase
         }
     }
 
-    /**
-     * @expectedException           InvalidArgumentException
-     * @expectedExceptionMessage    API Secret is invalid
-     */
     public function testApiResponseMissingApiSecret()
     {
         Configuration::instance()->cloud->apiSecret = null;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('API Secret is invalid');
 
         SignatureVerifier::verifyApiResponseSignature(
             self::$publicId,


### PR DESCRIPTION
### Brief Summary of Changes

This change replaces `phpunit/phpunit` v5 with `symfony/phpunit-bridge` which finally allows to run the tests on all supported PHP versions (5.6, 7.x, 8.x) using different PHPUnit versions, providing future-compatibility features.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

There are numerous additional changes, mainly in tests:

- Old-style `PHPUnit_Framework_*` namespaces were replaced with `PHPUnit\Framework\*`
- `assertArraySubset` calls were replaced with a simplified `assertSubset` method as it was removed in PHPUnit 9
- `assertInternalType` calls were replaced with `assertIs<type>` calls
- `assertContains` calls with string arguments were replaced with `assertStringContainsString`
- `@expectedException` annotations were replaced with `$this->expectException()` calls as they were removed in PHPUnit 9
- `assertRegExp` calls were replaced with `assertMatchesRegularExpression`
- Tests are now executed using GitHub Actions (I had some issues with Travis CI)
- Using PSR-4 autoloading in tests

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
