### PR TITLE
Use PHP in scripts

### DIFF
--- a/tools/allocate_test_cloud.sh
+++ b/tools/allocate_test_cloud.sh
@@ -6,4 +6,4 @@ SDK_NAME="${1}"
 
 CLOUD_DETAILS=$(curl -sS -d "{\"prefix\" : \"${SDK_NAME}\"}" "${API_ENDPOINT}")
 
-echo ${CLOUD_DETAILS} | python -c 'import json,sys;c=json.load(sys.stdin)["payload"];print("cloudinary://%s:%s@%s" % (c["cloudApiKey"], c["cloudApiSecret"], c["cloudName"]))'
+echo ${CLOUD_DETAILS} | php -r '$c = json_decode(stream_get_contents(STDIN))->payload; printf("cloudinary://%s:%s@%s", $c->cloudApiKey, $c->cloudApiSecret, $c->cloudName);'

--- a/tools/get_test_cloud.sh
+++ b/tools/get_test_cloud.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 PHP_VER=$(php -v | head -n 1 | cut -d ' ' -f 2);
-SDK_VER=$(grep -oiP '(?<="version": ")([a-zA-Z0-9\-.]+)(?=")' composer.json)
+SDK_VER=$(php -r "echo json_decode(file_get_contents('composer.json'))->version;")
 
 
 bash ${DIR}/allocate_test_cloud.sh "PHP ${PHP_VER} SDK ${SDK_VER}"


### PR DESCRIPTION
### Brief Summary of Changes
This PR improves DX by making it easier to run the scripts under `tools` directory - removes GNU `grep` dependency (not available in some distributions) and `python` (replaced with inline `php`).

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change DOES NOT require a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
