### PR TITLE
Allow Monolog v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "guzzlehttp/guzzle": "^6|^7",
     "shrikeh/teapot": "^1|^2",
     "ext-json": "*",
-    "monolog/monolog": "^1|^2",
+    "monolog/monolog": "^1|^2|^3",
     "psr/log" : "^1|^2|^3"
   },
   "require-dev": {

--- a/src/Api/Upload/CreativeTrait.php
+++ b/src/Api/Upload/CreativeTrait.php
@@ -293,8 +293,7 @@ trait CreativeTrait
             $params['tag'] = $tag;
         }
         return $params;
-
-     }
+    }
     /**
      * Create auto-generated video slideshows.
      *

--- a/src/Log/LoggerDecorator.php
+++ b/src/Log/LoggerDecorator.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
  * Backwards compatibility with PSR Log v1.
  */
 $r = new \ReflectionClass(LoggerInterface::class);
-if ( PHP_MAJOR_VERSION < 7 || !$r->getMethod('log')->hasReturnType()) {
+if (PHP_MAJOR_VERSION < 7 || !$r->getMethod('log')->hasReturnType()) {
     /**
      * Logger decorator trait that exposes PSR-3 Logger methods.
      */

--- a/src/Tag/Attribute/SrcSet.php
+++ b/src/Tag/Attribute/SrcSet.php
@@ -232,7 +232,6 @@ class SrcSet
                 if (! $count) {
                     break;
                 }
-
             }
         }
 

--- a/tests/CloudinaryTestCase.php
+++ b/tests/CloudinaryTestCase.php
@@ -14,12 +14,13 @@ use Cloudinary\Cloudinary;
 use Cloudinary\StringUtils;
 use Exception;
 use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use PHPUnit\Framework\Constraint\LogicalOr;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Constraint\IsType;
 use ReflectionException;
 use ReflectionMethod;
-
 
 if (! defined('JSON_INVALID_UTF8_SUBSTITUTE')) {
     //PHP < 7.2 Define it as 0 so it does nothing
@@ -235,6 +236,11 @@ abstract class CloudinaryTestCase extends TestCase
         $testHandler = $logger->getTestHandler();
 
         self::assertInstanceOf(TestHandler::class, $testHandler);
+
+        if (3 === Logger::API) {
+            $level = is_string($level) ? Level::fromName($level) : Level::fromValue($level);
+        }
+
         self::assertTrue(
             $testHandler->hasRecordThatContains($message, $level),
             sprintf('Object %s did not log the message or logged it with a different level', get_class($obj))

--- a/tests/Integration/Upload/UploadApiTest.php
+++ b/tests/Integration/Upload/UploadApiTest.php
@@ -496,7 +496,6 @@ final class UploadApiTest extends IntegrationTestCase
             1,
             'Unable to use eval upload parameter'
         );
-
     }
 
     /**

--- a/tests/Unit/Asset/AuthTokenTestCase.php
+++ b/tests/Unit/Asset/AuthTokenTestCase.php
@@ -41,4 +41,3 @@ class AuthTokenTestCase extends AssetTestCase
         );
     }
 }
-

--- a/tests/Unit/Tag/TagTest.php
+++ b/tests/Unit/Tag/TagTest.php
@@ -12,7 +12,6 @@ namespace Cloudinary\Test\Unit\Tag;
 
 use PHPUnit\Framework\TestCase;
 
-
 /**
  * Class TagTest
  */

--- a/tests/Unit/Upload/CreateSlideshowTest.php
+++ b/tests/Unit/Upload/CreateSlideshowTest.php
@@ -96,7 +96,5 @@ final class CreateSlideshowTest extends AssetTestCase
                 'upload_preset'           => self::UPLOAD_PRESET,
             ]
         );
-
     }
-
 }


### PR DESCRIPTION
### Brief Summary of Changes

This change allows installing Monolog v3: https://github.com/Seldaek/monolog/blob/main/UPGRADE.md#300
The only changes required are in the tests where we filter the messages by level which is now an enum instead of `int`.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

Monolog v3 requires PHP 8.1 so each version is tested in different PHP versions thanks to CI matrix.

Additional changes:
- fixed style using `vendor/bin/phpcbf`

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
