### PR TITLE
Add support for `assetsByAssetFolder` Admin API

### DIFF
--- a/src/Api/Admin/AssetsTrait.php
+++ b/src/Api/Admin/AssetsTrait.php
@@ -203,6 +203,31 @@ trait AssetsTrait
     }
 
     /**
+     * Lists assets in the specified asset folder.
+     *
+     * @param string $assetFolder The asset folder.
+     * @param array  $options     The optional parameters. See the
+     *                            <a href=https://cloudinary.com/documentation/dynamic_folders target="_blank"> Admin
+     *                            API</a> documentation.
+     *
+     * @return ApiResponse
+     *
+     * @see https://cloudinary.com/documentation/dynamic_folders
+     */
+    public function assetsByAssetFolder($assetFolder, $options = [])
+    {
+        $uri = [ApiEndPoint::ASSETS, 'by_asset_folder'];
+
+        $params                 = ArrayUtils::whitelist(
+            $options,
+            ['next_cursor', 'max_results', 'tags', 'moderations', 'context']
+        );
+        $params['asset_folder'] = $assetFolder;
+
+        return $this->apiClient->get($uri, $params);
+    }
+
+    /**
      * Returns the details of the specified asset and all its derived assets.
      *
      *
@@ -312,6 +337,8 @@ trait AssetsTrait
                 'background_removal',
                 'quality_override',
                 'notification_url',
+                'asset_folder',
+                'unique_display_name',
             ]
         );
 

--- a/src/Api/Upload/UploadTrait.php
+++ b/src/Api/Upload/UploadTrait.php
@@ -79,6 +79,7 @@ trait UploadTrait
             'type',
             'unique_filename',
             'upload_preset',
+            'use_asset_folder_as_public_id_prefix',
             'use_filename',
             'use_filename_as_display_name',
         ];

--- a/tests/Helpers/Feature.php
+++ b/tests/Helpers/Feature.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Cloudinary PHP package.
+ *
+ * (c) Cloudinary
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cloudinary\Test\Helpers;
+
+/**
+ * Class Feature
+ */
+class Feature
+{
+    const ALL             = 'all';              // Test all features.
+    const DYNAMIC_FOLDERS = 'dynamic_folders';  // Dynamic folders.
+}

--- a/tests/Integration/Admin/Assets/ListAssetsTest.php
+++ b/tests/Integration/Admin/Assets/ListAssetsTest.php
@@ -16,6 +16,7 @@ use Cloudinary\Asset\DeliveryType;
 use Cloudinary\Asset\ModerationStatus;
 use Cloudinary\Asset\ModerationType;
 use Cloudinary\Test\Helpers\Addon;
+use Cloudinary\Test\Helpers\Feature;
 use Cloudinary\Test\Integration\IntegrationTestCase;
 use Cloudinary\Test\Unit\Asset\AssetTestCase;
 use Exception;
@@ -268,6 +269,9 @@ final class ListAssetsTest extends IntegrationTestCase
      */
     public function testListUploadedAssetsByAssetFolder()
     {
+        if (! self::shouldTestFeature(Feature::DYNAMIC_FOLDERS)) {
+            self::markTestSkipped('Skipping ListUploadedAssetsByAssetFolder test.');
+        }
         $result = self::$adminApi->assetsByAssetFolder(self::$UNIQUE_ASSET_FOLDER);
 
         self::assertValidAsset($result['resources'][0], [AssetType::KEY => AssetType::VIDEO]);

--- a/tests/Integration/Admin/Assets/ListAssetsTest.php
+++ b/tests/Integration/Admin/Assets/ListAssetsTest.php
@@ -34,6 +34,7 @@ final class ListAssetsTest extends IntegrationTestCase
     private static $UNIQUE_TEST_TAG_TO_ONE_IMAGE_ASSET;
     private static $UNIQUE_PREFIX;
     private static $FULL_UNIQUE_PREFIX;
+    private static $UNIQUE_ASSET_FOLDER;
 
     /**
      * @throws ApiError
@@ -49,6 +50,7 @@ final class ListAssetsTest extends IntegrationTestCase
         self::$UNIQUE_CONTEXT                     = self::$UNIQUE_CONTEXT_KEY . '=' . self::$UNIQUE_CONTEXT_VALUE;
         self::$UNIQUE_TEST_TAG_TO_ONE_IMAGE_ASSET = self::CLASS_PREFIX . 'unique_tag_to_one_image_asset_' .
                                                     self::$UNIQUE_TEST_TAG;
+        self::$UNIQUE_ASSET_FOLDER                = self::$FULL_UNIQUE_PREFIX . '_asset_folder';
 
         self::createTestAssets(
             [
@@ -57,7 +59,7 @@ final class ListAssetsTest extends IntegrationTestCase
                         'tags'              => [self::$UNIQUE_TEST_TAG_TO_ONE_IMAGE_ASSET],
                         'context'           => self::$UNIQUE_CONTEXT,
                         ModerationType::KEY => ModerationType::MANUAL,
-                    ]
+                    ],
                 ],
                 self::TEST_ASSET,
                 [
@@ -65,6 +67,7 @@ final class ListAssetsTest extends IntegrationTestCase
                         'context'      => self::$UNIQUE_CONTEXT,
                         'file'         => self::TEST_DOCX_PATH,
                         AssetType::KEY => AssetType::RAW,
+                        'asset_folder' => self::$UNIQUE_ASSET_FOLDER,
                     ],
                 ],
                 [
@@ -72,6 +75,7 @@ final class ListAssetsTest extends IntegrationTestCase
                         'context'      => self::$UNIQUE_CONTEXT,
                         'file'         => self::TEST_VIDEO_PATH,
                         AssetType::KEY => AssetType::VIDEO,
+                        'asset_folder' => self::$UNIQUE_ASSET_FOLDER,
                     ],
                 ],
             ],
@@ -216,7 +220,7 @@ final class ListAssetsTest extends IntegrationTestCase
         $result = self::$adminApi->assetsByIds(
             [
                 self::getTestAssetPublicId(self::$UNIQUE_PREFIX),
-                self::getTestAssetPublicId(self::TEST_ASSET)
+                self::getTestAssetPublicId(self::TEST_ASSET),
             ]
         );
 
@@ -250,12 +254,24 @@ final class ListAssetsTest extends IntegrationTestCase
         $result = self::$adminApi->assetsByAssetIds(
             [
                 self::getTestAssetAssetId(self::$UNIQUE_PREFIX),
-                self::getTestAssetAssetId(self::TEST_ASSET)
+                self::getTestAssetAssetId(self::TEST_ASSET),
             ]
         );
 
         self::assertValidAsset($result['resources'][0]);
         self::assertValidAsset($result['resources'][1]);
+        self::assertCount(2, $result['resources']);
+    }
+
+    /**
+     * Get uploaded assets in the Asset folder.
+     */
+    public function testListUploadedAssetsByAssetFolder()
+    {
+        $result = self::$adminApi->assetsByAssetFolder(self::$UNIQUE_ASSET_FOLDER);
+
+        self::assertValidAsset($result['resources'][0], [AssetType::KEY => AssetType::VIDEO]);
+        self::assertValidAsset($result['resources'][1], [AssetType::KEY => AssetType::RAW]);
         self::assertCount(2, $result['resources']);
     }
 

--- a/tests/Integration/Admin/UploadPresetsTest.php
+++ b/tests/Integration/Admin/UploadPresetsTest.php
@@ -138,7 +138,8 @@ final class UploadPresetsTest extends IntegrationTestCase
                 'tags' => self::$ASSET_TAGS,
                 'allowed_formats' => 'jpg',
                 'live' => true,
-                'eval' => self::TEST_EVAL_STR
+                'eval' => self::TEST_EVAL_STR,
+                'use_asset_folder_as_public_id_prefix' => true,
             ]
         );
 
@@ -154,7 +155,8 @@ final class UploadPresetsTest extends IntegrationTestCase
                 'tags' => self::$ASSET_TAGS,
                 'allowed_formats' => ['jpg'],
                 'live' => true,
-                'eval' => self::TEST_EVAL_STR
+                'eval' => self::TEST_EVAL_STR,
+                'use_asset_folder_as_public_id_prefix' => true,
             ]
         );
     }

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -93,6 +93,23 @@ abstract class IntegrationTestCase extends CloudinaryTestCase
     }
 
     /**
+     * Should a certain feature be tested?
+     *
+     * @param string $feature The feature to test.
+     *
+     * @return bool
+     */
+    protected static function shouldTestFeature($feature)
+    {
+        $cldTestFeatures = strtolower(getenv('CLD_TEST_FEATURES'));
+        if ($cldTestFeatures === Addon::ALL) {
+            return true;
+        }
+
+        return ArrayUtils::inArrayI($feature, explode(',', $cldTestFeatures));
+    }
+
+    /**
      * @return bool
      */
     protected static function shouldRunDestructiveTests()

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -23,6 +23,7 @@ use Cloudinary\Configuration\ConfigUtils;
 use Cloudinary\StringUtils;
 use Cloudinary\Test\CloudinaryTestCase;
 use Cloudinary\Test\Helpers\Addon;
+use Cloudinary\Test\Helpers\Feature;
 use Cloudinary\Test\Unit\Asset\AssetTestCase;
 use Exception;
 use GuzzleHttp\Client;
@@ -102,7 +103,7 @@ abstract class IntegrationTestCase extends CloudinaryTestCase
     protected static function shouldTestFeature($feature)
     {
         $cldTestFeatures = strtolower(getenv('CLD_TEST_FEATURES'));
-        if ($cldTestFeatures === Addon::ALL) {
+        if ($cldTestFeatures === Feature::ALL) {
             return true;
         }
 

--- a/tests/Unit/Admin/AssetsTest.php
+++ b/tests/Unit/Admin/AssetsTest.php
@@ -77,10 +77,23 @@ final class AssetsTest extends UnitTestCase
     public function testUpdateAssetFields()
     {
         $mockAdminApi = new MockAdminApi();
-        $mockAdminApi->update(self::$UNIQUE_TEST_ID, ['metadata' => ['key'=>'value']]);
+        $mockAdminApi->update(self::$UNIQUE_TEST_ID,
+            [
+                'metadata'            => ['key' => 'value'],
+                'asset_folder'        => 'asset_folder',
+                'unique_display_name' => true,
+            ]
+        );
         $lastRequest = $mockAdminApi->getMockHandler()->getLastRequest();
 
         self::assertRequestUrl($lastRequest, '/resources/image/upload/' . self::$UNIQUE_TEST_ID);
-        self::assertRequestBodySubset($lastRequest, ['metadata'=>'key=value']);
+        self::assertRequestBodySubset(
+            $lastRequest,
+            [
+                'metadata'            => 'key=value',
+                'asset_folder'        => 'asset_folder',
+                'unique_display_name' => true,
+            ]
+        );
     }
 }

--- a/tests/Unit/Upload/UploadApiTest.php
+++ b/tests/Unit/Upload/UploadApiTest.php
@@ -118,11 +118,12 @@ final class UploadApiTest extends AssetTestCase
     public function testUploadFolderDecoupling()
     {
         $options = [
-            'public_id_prefix'             => self::FD_PID_PREFIX,
-            'asset_folder'                 => self::ASSET_FOLDER,
-            'display_name'                 => self::ASSET_DISPLAY_NAME,
-            'use_filename_as_display_name' => true,
-            'folder'                       => self::NESTED_FOLDER,
+            'public_id_prefix'                     => self::FD_PID_PREFIX,
+            'asset_folder'                         => self::ASSET_FOLDER,
+            'use_asset_folder_as_public_id_prefix' => true,
+            'display_name'                         => self::ASSET_DISPLAY_NAME,
+            'use_filename_as_display_name'         => true,
+            'folder'                               => self::NESTED_FOLDER,
         ];
 
         $mockUploadApi = new MockUploadApi();


### PR DESCRIPTION
### Brief Summary of Changes
This PR adds support for the new Admin API function `assetsByAssetFolder`.

In addition it adds support for the following parameters:
- `asset_folder`
- `unique_display_name`
- `use_asset_folder_as_public_id_prefix`

to the relevant admin and upload API functions.

Please note that the integration test for the new function was set with conditional flag, since by default this API is not available for all accounts.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
