### PR TITLE
Fix format for fetched assets

### DIFF
--- a/src/Asset/Descriptor/AssetDescriptor.php
+++ b/src/Asset/Descriptor/AssetDescriptor.php
@@ -224,8 +224,10 @@ class AssetDescriptor implements AssetInterface
             )
             = FileUtils::splitPathFilenameExtension($source);
 
-        // Explicit 'format' parameter overrides extension.
-        ArrayUtils::addNonEmpty($assetJson, 'extension', ArrayUtils::get($params, 'format'));
+        // Explicit 'format' parameter overrides extension. (Fetch URLs are not affected).
+        if ($assetJson['delivery_type'] != DeliveryType::FETCH) {
+            ArrayUtils::addNonEmpty($assetJson, 'extension', ArrayUtils::get($params, 'format'));
+        }
 
         return self::fromJson(['asset' => $assetJson]);
     }

--- a/src/Tag/VideoSourceTag.php
+++ b/src/Tag/VideoSourceTag.php
@@ -10,9 +10,12 @@
 
 namespace Cloudinary\Tag;
 
+use Cloudinary\Asset\DeliveryType;
 use Cloudinary\Asset\Video;
 use Cloudinary\ClassUtils;
 use Cloudinary\Configuration\Configuration;
+use Cloudinary\Transformation\Delivery;
+use Cloudinary\Transformation\Format;
 use Cloudinary\Transformation\VideoTransformation;
 
 /**
@@ -94,8 +97,7 @@ class VideoSourceTag extends BaseTag
     public function type($type, $codecs = null)
     {
         $this->sourceType = ClassUtils::verifyInstance($type, VideoSourceType::class, null, $codecs);
-
-        $this->video->asset->extension = $this->sourceType->type;
+        $this->video->setFormat($this->sourceType->type);
 
         return $this;
     }

--- a/src/Tag/VideoTag.php
+++ b/src/Tag/VideoTag.php
@@ -301,7 +301,7 @@ class VideoTag extends BaseTag implements VideoTransformationInterface
 
         if (! array_key_exists('poster', $this->attributes)) {
             $poster                   = new Image($this->video);
-            $poster->asset->extension = $this->config->tag->videoPosterFormat;
+            $poster->setFormat($this->config->tag->videoPosterFormat);
 
             $attributes['poster'] = $poster;
         }

--- a/src/Tag/VideoThumbnailTag.php
+++ b/src/Tag/VideoThumbnailTag.php
@@ -36,7 +36,7 @@ class VideoThumbnailTag extends ImageTag
     {
         parent::image(new Video($source, $configuration), $configuration);
 
-        $this->image->asset->extension = $configuration->tag->videoPosterFormat;
+        $this->image->setFormat($configuration->tag->videoPosterFormat);
 
         return $this;
     }

--- a/tests/Unit/Asset/AssetTestCase.php
+++ b/tests/Unit/Asset/AssetTestCase.php
@@ -53,6 +53,8 @@ abstract class AssetTestCase extends UnitTestCase
     const FETCH_IMAGE_URL            = 'https://res.cloudinary.com/demo/image/upload/' . self::IMAGE_NAME;
     const FETCH_IMAGE_URL_WITH_QUERY = 'https://res.cloudinary.com/demo/image/upload/' . self::IMAGE_NAME . '?q=a';
 
+    const FETCH_VIDEO_URL = 'https://res.cloudinary.com/demo/video/upload/dog.mp4';
+
     const PROTOCOL_HTTP  = 'http';
     const PROTOCOL_HTTPS = 'https';
 

--- a/tests/Unit/Asset/MediaFromParamsTest.php
+++ b/tests/Unit/Asset/MediaFromParamsTest.php
@@ -307,6 +307,24 @@ final class MediaFromParamsTest extends AssetTestCase
     }
 
     /**
+     * Should set format as transformation parameter for fetched URLs.
+     */
+    public function testFetchWithFormat()
+    {
+        $options = ['type' => DeliveryType::FETCH, 'format' => 'jpg'];
+
+        self::assertMediaFromParamsUrl(
+            self::FETCH_IMAGE_URL,
+            $options,
+            [
+                'delivery_type' => DeliveryType::FETCH,
+                'source'        => self::FETCH_IMAGE_URL,
+                'path'          => 'f_jpg',
+            ]
+        );
+    }
+
+    /**
      * Tests force_version parameter under different conditions.
      */
     public function testForceVersion()

--- a/tests/Unit/Tag/TagFromParamsTest.php
+++ b/tests/Unit/Tag/TagFromParamsTest.php
@@ -11,6 +11,7 @@
 namespace Cloudinary\Test\Unit\Tag;
 
 use Cloudinary\ArrayUtils;
+use Cloudinary\Asset\DeliveryType;
 use Cloudinary\Asset\Media;
 use Cloudinary\Configuration\Configuration;
 use Cloudinary\Tag\ImageTag;
@@ -31,7 +32,9 @@ final class TagFromParamsTest extends ImageTagTestCase
 
     const DEFAULT_PATH        = 'http://res.cloudinary.com/test123';
     const DEFAULT_UPLOAD_PATH = 'http://res.cloudinary.com/test123/image/upload/';
-    const VIDEO_UPLOAD_PATH   = 'http://res.cloudinary.com/test123/video/upload/';
+    const VIDEO_PATH   = 'http://res.cloudinary.com/test123/video/';
+    const VIDEO_UPLOAD_PATH   = self::VIDEO_PATH . 'upload/';
+    const VIDEO_FETCH_PATH   = self::VIDEO_PATH . 'fetch/';
 
     private static $publicId                = 'sample.jpg';
     private static $commonTransformationStr = 'e_sepia';
@@ -514,6 +517,21 @@ final class TagFromParamsTest extends ImageTagTestCase
             "<source src='$expectedUrl.ogv' type='video/ogg'>" .
             '</video>',
             VideoTag::fromParams('movie')
+        );
+    }
+
+    public function testVideoTagFetch()
+    {
+        $videoUrl = self::FETCH_VIDEO_URL;
+        $prefixUrl = self::VIDEO_FETCH_PATH;
+
+        self::assertStrEquals(
+            "<video poster='${prefixUrl}f_jpg/$videoUrl'>" .
+            "<source src='${prefixUrl}f_webm/$videoUrl' type='video/webm'>" .
+            "<source src='${prefixUrl}f_mp4/$videoUrl' type='video/mp4'>" .
+            "<source src='${prefixUrl}f_ogv/$videoUrl' type='video/ogg'>" .
+            '</video>',
+            VideoTag::fromParams($videoUrl, [DeliveryType::KEY => DeliveryType::FETCH])
         );
     }
 

--- a/tests/Unit/Tag/VideoTagTest.php
+++ b/tests/Unit/Tag/VideoTagTest.php
@@ -23,6 +23,7 @@ use Cloudinary\Transformation\Transformation;
  */
 final class VideoTagTest extends TagTestCase
 {
+    const FETCH_VIDEO_URL_PREFIX = 'https://res.cloudinary.com/test123/video/fetch/';
     protected $video;
 
     protected $defaultSourcesStr =
@@ -56,6 +57,29 @@ final class VideoTagTest extends TagTestCase
         self::assertEquals(
             (string)$expected,
             (string)VideoTag::upload(self::VIDEO_NAME)
+        );
+    }
+
+    public function testVideoTagFetchVideo()
+    {
+        $videoUrl  = self::FETCH_VIDEO_URL;
+        $prefixUrl = self::FETCH_VIDEO_URL_PREFIX;
+
+        $expected = "<video poster=\"${prefixUrl}f_jpg/$videoUrl\">" . "\n" .
+                    "<source src=\"${prefixUrl}f_mp4/vc_h265/$videoUrl\" type=\"video/mp4; codecs=hev1\">" . "\n" .
+                    "<source src=\"${prefixUrl}f_webm/vc_vp9/$videoUrl\" type=\"video/webm; codecs=vp9\">" . "\n" .
+                    "<source src=\"${prefixUrl}f_mp4/vc_auto/$videoUrl\" type=\"video/mp4\">" . "\n" .
+                    "<source src=\"${prefixUrl}f_webm/vc_auto/$videoUrl\" type=\"video/webm\">" . "\n" .
+                    '</video>';
+
+        self::assertStrEquals(
+            $expected,
+            VideoTag::fetch(self::FETCH_VIDEO_URL)
+        );
+
+        self::assertStrEquals(
+            $expected,
+            new VideoTag(Video::fetch(self::FETCH_VIDEO_URL))
         );
     }
 


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->
Some tags were rendered incorrectly when remote(fetch) URL was provided as a source.
This PR handles `fetch` delivery type, by setting `f_` transformation parameter instead.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
