### PR TITLE
Fix `SetMetadataField` default value handling

### DIFF
--- a/src/Api/Metadata/Metadata.php
+++ b/src/Api/Metadata/Metadata.php
@@ -53,6 +53,8 @@ abstract class Metadata implements JsonSerializable
                 foreach ($value as $subArrayValue) {
                     if (method_exists($subArrayValue, 'jsonSerialize')) {
                         $subArray[] = $subArrayValue->jsonSerialize();
+                    } else {
+                        $subArray[] = $subArrayValue;
                     }
                 }
                 $snakeCaseProperties[StringUtils::camelCaseToSnakeCase($key)] = $subArray;

--- a/src/Api/Metadata/MetadataField.php
+++ b/src/Api/Metadata/MetadataField.php
@@ -96,7 +96,7 @@ abstract class MetadataField extends Metadata
      */
     public function setDefaultValue($defaultValue)
     {
-        $this->defaultValue = (string)$defaultValue;
+        $this->defaultValue = $defaultValue;
     }
 
     /**

--- a/tests/Integration/Admin/MetadataFieldsTest.php
+++ b/tests/Integration/Admin/MetadataFieldsTest.php
@@ -243,6 +243,7 @@ class MetadataFieldsTest extends IntegrationTestCase
     {
         $setMetadataField = new SetMetadataField(self::$EXTERNAL_ID_SET, self::$DATASOURCE_MULTIPLE);
         $setMetadataField->setExternalId(self::$EXTERNAL_ID_SET);
+        $setMetadataField->setDefaultValue([self::$DATASOURCE_ENTRY_EXTERNAL_ID, 'v4']);
 
         $result = self::$adminApi->addMetadataField($setMetadataField);
 
@@ -252,7 +253,8 @@ class MetadataFieldsTest extends IntegrationTestCase
             [
                 'label' => self::$EXTERNAL_ID_SET,
                 'external_id' => self::$EXTERNAL_ID_SET,
-                'mandatory' => false
+                'mandatory' => false,
+                'default_value' => [self::$DATASOURCE_ENTRY_EXTERNAL_ID, 'v4']
             ]
         );
     }


### PR DESCRIPTION
### Brief Summary of Changes
Fix handling of `SetMetadataField` default value.

Fixes #369 

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
