### PR TITLE
Add support for `on_success` upload parameter

### DIFF
--- a/src/Api/Upload/UploadTrait.php
+++ b/src/Api/Upload/UploadTrait.php
@@ -56,6 +56,7 @@ trait UploadTrait
             'eager_async',
             'eager_notification_url',
             'eval',
+            'on_success',
             'exif',
             'faces',
             'filename_override',

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -44,9 +44,10 @@ abstract class IntegrationTestCase extends CloudinaryTestCase
     const TEST_DOCX_PATH      = self::TEST_ASSETS_DIR . AssetTestCase::DOCX_NAME;
     const TEST_VIDEO_PATH     = self::TEST_ASSETS_DIR . AssetTestCase::VIDEO_NAME;
     const TEST_LOGGING        = ['logging' => ['test' => ['level' => 'debug']]];
-    const TEST_EVAL_STR
-                              = 'if (resource_info["width"] < 450) { upload_options["quality_analysis"] = true }; ' .
+    const TEST_EVAL_STR       = 'if (resource_info["width"] < 450) { upload_options["quality_analysis"] = true }; ' .
                                 'upload_options["context"] = "width=" + resource_info["width"]';
+
+    const TEST_ON_SUCCESS_STR = 'current_asset.update({tags: ["autocaption"]});';
 
     private static $TEST_ASSETS = [];
 

--- a/tests/Unit/Upload/UploadApiTest.php
+++ b/tests/Unit/Upload/UploadApiTest.php
@@ -15,6 +15,7 @@ use Cloudinary\Configuration\ApiConfig;
 use Cloudinary\Configuration\Configuration;
 use Cloudinary\Test\Helpers\MockUploadApi;
 use Cloudinary\Test\Helpers\RequestAssertionsTrait;
+use Cloudinary\Test\Integration\IntegrationTestCase;
 use Cloudinary\Test\Unit\Asset\AssetTestCase;
 
 /**
@@ -38,6 +39,7 @@ final class UploadApiTest extends AssetTestCase
             'cinemagraph_analysis'   => true,
             'media_metadata'         => true,
             'visual_search'          => true,
+            'on_success'             => IntegrationTestCase::TEST_ON_SUCCESS_STR,
         ];
 
         $mockUploadApi = new MockUploadApi();
@@ -49,7 +51,7 @@ final class UploadApiTest extends AssetTestCase
         $lastOptions = $mockUploadApi->getApiClient()->getRequestMultipartOptions();
 
         foreach ($params as $param => $value) {
-            self::assertEquals($value ? '1' : '0', $lastOptions[$param]);
+            self::assertEquals(is_bool($value) ? $value ? '1' : '0': $value, $lastOptions[$param]);
         }
     }
 


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
