### PR TITLE
Add support for `image_file` in `visualSearch` Admin API

### DIFF
--- a/src/Api/Admin/AssetsTrait.php
+++ b/src/Api/Admin/AssetsTrait.php
@@ -237,6 +237,8 @@ trait AssetsTrait
      *
      * @return ApiResponse
      *
+     * @throws ApiError
+     *
      * @see https://cloudinary.com/documentation/admin_api#visual_search_for_resources
      */
     public function visualSearch($options = [])
@@ -245,7 +247,15 @@ trait AssetsTrait
 
         $params = ArrayUtils::whitelist($options, ['image_url', 'image_asset_id', 'text']);
 
-        return $this->apiClient->get($uri, $params);
+        // Special handling for file inside Admin API.
+        if (array_key_exists('image_file', $options)) {
+            $options['file_field'] = 'image_file';
+            $options['unsigned'] = true;
+
+            return $this->apiClient->postFile($uri, $options['image_file'], $params, $options);
+        }
+
+        return $this->apiClient->postForm($uri, $params);
     }
 
     /**

--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -380,7 +380,7 @@ class ApiClient extends BaseApiClient
     protected function postSingleChunkAsync($endPoint, $singleChunk, $parameters, $options = [])
     {
         $filePart = [
-            'name'     => 'file',
+            'name'     => ArrayUtils::get($options, 'file_field', 'file'),
             'contents' => $singleChunk,
         ];
 

--- a/tests/Unit/Admin/AssetsTest.php
+++ b/tests/Unit/Admin/AssetsTest.php
@@ -10,8 +10,11 @@
 
 namespace Cloudinary\Test\Unit\Admin;
 
+use Cloudinary\Api\Exception\ApiError;
 use Cloudinary\Test\Helpers\MockAdminApi;
 use Cloudinary\Test\Helpers\RequestAssertionsTrait;
+use Cloudinary\Test\Integration\IntegrationTestCase;
+use Cloudinary\Test\Unit\Asset\AssetTestCase;
 use Cloudinary\Test\Unit\UnitTestCase;
 
 /**
@@ -21,7 +24,10 @@ final class AssetsTest extends UnitTestCase
 {
     use RequestAssertionsTrait;
 
-    public function restoreDeletedAssetSpecificVersionDataProvider()
+    /**
+     * @return array[]
+     */
+    protected function restoreDeletedAssetSpecificVersionDataProvider()
     {
         return [
             [
@@ -184,5 +190,81 @@ final class AssetsTest extends UnitTestCase
                 'assets_to_unrelate' => $testAssetIds,
             ]
         );
+    }
+
+
+    /**
+     * @return array[]
+     */
+    protected function visualSearchDataProvider()
+    {
+        return [
+            [
+                'options'    => [
+                    'image_url' => AssetTestCase::FETCH_IMAGE_URL,
+                ],
+                'url'        => '/resources/visual_search',
+                'bodyFields' => [
+                    'image_url' => AssetTestCase::FETCH_IMAGE_URL,
+                ],
+            ],
+            [
+                'options'    => [
+                    'image_asset_id' => self::API_TEST_ASSET_ID,
+                ],
+                'url'        => '/resources/visual_search',
+                'bodyFields' => [
+                    'image_asset_id' => self::API_TEST_ASSET_ID,
+                ],
+            ],
+            [
+                'options'    => [
+                    'text' => 'sample image',
+                ],
+                'url'        => '/resources/visual_search',
+                'bodyFields' => [
+                    'text' => 'sample image',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test Visual search.
+     *
+     * @dataProvider visualSearchDataProvider
+     *
+     * @param array  $options
+     * @param string $url
+     * @param array  $bodyFields
+     *
+     * @throws ApiError
+     */
+    public function testVisualSearch($options, $url, $bodyFields)
+    {
+        $mockAdminApi = new MockAdminApi();
+        $mockAdminApi->visualSearch($options);
+        $lastRequest = $mockAdminApi->getMockHandler()->getLastRequest();
+
+        self::assertRequestUrl($lastRequest, $url);
+        self::assertRequestBodySubset($lastRequest, $bodyFields);
+    }
+
+    /**
+     * Test Visual search using image file.
+     *
+     * @throws ApiError
+     */
+    public function testVisualSearchImageFile()
+    {
+        $mockAdminApi = new MockAdminApi();
+        $mockAdminApi->visualSearch(['image_file' => IntegrationTestCase::TEST_IMAGE_PATH]);
+        $lastRequest = $mockAdminApi->getMockHandler()->getLastRequest();
+
+        self::assertRequestUrl($lastRequest, '/resources/visual_search');
+        $body = $lastRequest->getBody()->getContents();
+
+        self::assertStringContainsString('image_file', $body);
+        self::assertStringContainsString('Content-Length: 5110', $body);
     }
 }

--- a/tests/Unit/Admin/AssetsTest.php
+++ b/tests/Unit/Admin/AssetsTest.php
@@ -27,7 +27,7 @@ final class AssetsTest extends UnitTestCase
     /**
      * @return array[]
      */
-    protected function restoreDeletedAssetSpecificVersionDataProvider()
+    public function restoreDeletedAssetSpecificVersionDataProvider()
     {
         return [
             [
@@ -196,7 +196,7 @@ final class AssetsTest extends UnitTestCase
     /**
      * @return array[]
      */
-    protected function visualSearchDataProvider()
+    public function visualSearchDataProvider()
     {
         return [
             [


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
