### PR TITLE
Add support for `allowDynamicListValues` parameter in `MetadataField`

### DIFF
--- a/src/Api/Metadata/MetadataFieldList.php
+++ b/src/Api/Metadata/MetadataFieldList.php
@@ -20,6 +20,7 @@ use InvalidArgumentException;
 abstract class MetadataFieldList extends MetadataField
 {
     protected MetadataDataSource $datasource;
+    protected bool $allowDynamicListValues;
 
     /**
      * The MetadataFieldList constructor.
@@ -41,7 +42,7 @@ abstract class MetadataFieldList extends MetadataField
      */
     public function getPropertyKeys(): array
     {
-        return array_merge(parent::getPropertyKeys(), ['datasource']);
+        return array_merge(parent::getPropertyKeys(), ['datasource', 'allowDynamicListValues']);
     }
 
     /**
@@ -70,5 +71,23 @@ abstract class MetadataFieldList extends MetadataField
         } else {
             throw new InvalidArgumentException('The specified MetadataFieldList datasource is not valid.');
         }
+    }
+
+    /**
+     * Gets the value indicating whether the field should allow dynamic list values.
+     */
+    public function isAllowDynamicListValues(): bool
+    {
+        return $this->allowDynamicListValues;
+    }
+
+    /**
+     * Sets the value indicating whether the field should allow dynamic list values.
+     *
+     * @param bool $allowDynamicListValues The value to set.
+     */
+    public function setAllowDynamicListValues(bool $allowDynamicListValues = true): void
+    {
+        $this->allowDynamicListValues = $allowDynamicListValues;
     }
 }

--- a/tests/Integration/Admin/MetadataFieldsTest.php
+++ b/tests/Integration/Admin/MetadataFieldsTest.php
@@ -246,6 +246,7 @@ class MetadataFieldsTest extends IntegrationTestCase
         $setMetadataField = new SetMetadataField(self::$EXTERNAL_ID_SET, self::$DATASOURCE_MULTIPLE);
         $setMetadataField->setExternalId(self::$EXTERNAL_ID_SET);
         $setMetadataField->setDefaultValue([self::$DATASOURCE_ENTRY_EXTERNAL_ID, 'v4']);
+        $setMetadataField->setAllowDynamicListValues(false);
 
         $result = self::$adminApi->addMetadataField($setMetadataField);
 
@@ -256,7 +257,8 @@ class MetadataFieldsTest extends IntegrationTestCase
                 'label' => self::$EXTERNAL_ID_SET,
                 'external_id' => self::$EXTERNAL_ID_SET,
                 'mandatory' => false,
-                'default_value' => [self::$DATASOURCE_ENTRY_EXTERNAL_ID, 'v4']
+                'default_value' => [self::$DATASOURCE_ENTRY_EXTERNAL_ID, 'v4'],
+                'allow_dynamic_list_values' => false,
             ]
         );
     }

--- a/tests/Unit/Admin/MetadataFieldsTest.php
+++ b/tests/Unit/Admin/MetadataFieldsTest.php
@@ -30,12 +30,13 @@ class MetadataFieldsTest extends UnitTestCase
     const EXTERNAL_ID_INT    = 'metadata_external_id_int';
     const EXTERNAL_ID_ENUM   = 'metadata_external_id_enum';
     const EXTERNAL_ID_DELETE = 'metadata_deletion_test';
-    const DATASOURCE_SINGLE  = [
-        [
-            'value'       => 'v1',
-            'external_id' => 'metadata_datasource_entry_external_id'
-        ]
-    ];
+    const DATASOURCE_SINGLE
+                             = [
+            [
+                'value'       => 'v1',
+                'external_id' => 'metadata_datasource_entry_external_id',
+            ],
+        ];
 
     /**
      * Test getting a list of all metadata fields.
@@ -65,7 +66,7 @@ class MetadataFieldsTest extends UnitTestCase
 
         $stringMetadataField = new StringMetadataField(self::EXTERNAL_ID_STRING);
         $stringMetadataField->setExternalId(self::EXTERNAL_ID_STRING);
-        $stringMetadataField->setRestrictions(["readonly_ui" => true]);
+        $stringMetadataField->setRestrictions(['readonly_ui' => true]);
         $stringMetadataField->setMandatory(false);
         $stringMetadataField->setDefaultDisabled();
 
@@ -81,7 +82,7 @@ class MetadataFieldsTest extends UnitTestCase
                 'external_id'      => self::EXTERNAL_ID_STRING,
                 'label'            => self::EXTERNAL_ID_STRING,
                 'mandatory'        => false,
-                'restrictions'     => ["readonly_ui" => true],
+                'restrictions'     => ['readonly_ui' => true],
                 'default_disabled' => true,
             ]
         );
@@ -109,7 +110,7 @@ class MetadataFieldsTest extends UnitTestCase
             [
                 'type'        => MetadataFieldType::INTEGER,
                 'external_id' => self::EXTERNAL_ID_INT,
-                'label'       => self::EXTERNAL_ID_INT
+                'label'       => self::EXTERNAL_ID_INT,
             ]
         );
     }
@@ -126,6 +127,7 @@ class MetadataFieldsTest extends UnitTestCase
         $enumMetadataField = new EnumMetadataField(self::EXTERNAL_ID_ENUM, self::DATASOURCE_SINGLE);
         $enumMetadataField->setDataSource(self::DATASOURCE_SINGLE);
         $enumMetadataField->setExternalId(self::EXTERNAL_ID_ENUM);
+        $enumMetadataField->setAllowDynamicListValues();
 
         $mockAdminApi->addMetadataField($enumMetadataField);
         $lastRequest = $mockAdminApi->getMockHandler()->getLastRequest();
@@ -135,12 +137,14 @@ class MetadataFieldsTest extends UnitTestCase
         self::assertRequestFields(
             $lastRequest,
             [
-                'datasource' => [
-                    'values' => self::DATASOURCE_SINGLE
+                'datasource'                => [
+                    'values' => self::DATASOURCE_SINGLE,
                 ],
-                'external_id' => self::EXTERNAL_ID_ENUM,
-                'label' => self::EXTERNAL_ID_ENUM,
-                'type' => MetadataFieldType::ENUM
+                'external_id'               => self::EXTERNAL_ID_ENUM,
+                'label'                     => self::EXTERNAL_ID_ENUM,
+                'type'                      => MetadataFieldType::ENUM,
+                'allow_dynamic_list_values' => true,
+
             ]
         );
     }


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
