### PR TITLE
Fix array offset error in FileUtils when the file doesn't exist

### DIFF
--- a/src/Utils/FileUtils.php
+++ b/src/Utils/FileUtils.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Cloudinary PHP package.
  *
@@ -137,7 +138,7 @@ class FileUtils
 
         if (! $fp) {
             $err = error_get_last();
-            throw new GeneralError($err['message']);
+            throw new GeneralError($err['message'] ?? 'Failed to open file: ' . $filename);
         }
 
         return $fp;

--- a/tests/Unit/Utils/FileUtilsTest.php
+++ b/tests/Unit/Utils/FileUtilsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Cloudinary PHP package.
  *
@@ -10,6 +11,7 @@
 
 namespace Cloudinary\Test\Unit\Utils;
 
+use Cloudinary\Api\Exception\GeneralError;
 use Cloudinary\FileUtils;
 use Cloudinary\Tag\ImageTag;
 use PHPUnit\Framework\TestCase;
@@ -63,5 +65,40 @@ final class FileUtilsTest extends TestCase
         foreach ($files as $file) {
             self::assertEquals($file[1], FileUtils::splitPathFilenameExtension($file[0]));
         }
+    }
+
+    public function testSafeFileOpenWithExistingFile()
+    {
+        $existingFile = __DIR__ . '/../../assets/sample.png';
+        $resource = FileUtils::safeFileOpen($existingFile, 'rb');
+
+        self::assertIsResource($resource);
+        self::assertEquals('stream', get_resource_type($resource));
+
+        fclose($resource);
+    }
+
+    public function testSafeFileOpenWithNonExistingFile()
+    {
+        $nonExistingFile = __DIR__ . '/../../assets/non_existing_file.txt';
+
+        $this->expectException(GeneralError::class);
+        FileUtils::safeFileOpen($nonExistingFile, 'rb');
+    }
+
+    public function testSafeFileOpenWithNonExistingFolder()
+    {
+        $nonExistingFile = 'foo/bar';
+
+        $this->expectException(GeneralError::class);
+        FileUtils::safeFileOpen($nonExistingFile, 'rb');
+    }
+
+    public function testSafeFileOpenWithEmptyPath()
+    {
+        $this->expectException(GeneralError::class);
+        $this->expectExceptionMessage('Path cannot be empty');
+
+        FileUtils::safeFileOpen('', 'rb');
     }
 }


### PR DESCRIPTION
### Brief Summary of Changes

I ran into a very weird issue on my Laravel project. When the file doesn't exist, I get this error while trying to upload the file:

```
   WARNING  Trying to access array offset on null in vendor/cloudinary/cloudinary_php/src/Utils/FileUtils.php on line 141.
```

This is the culprit method: https://github.com/cloudinary/cloudinary_php/blob/5b7d5480ba91d1df19ebb0041b23d85a228845ba/src/Utils/FileUtils.php#L130

What happens is that `$err = error_get_last();` on line 139 returns `NULL`.

This is weird because when I forked the project and added tests locally to check how it behaves with a non-existing file, it worked as expected.

I discovered that it's because of how Laravel handles error handling. It uses a [custom error handler](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php) which intercepts all errors (including warnings), and PHP's built-in error system has no clue about what happened. In the end, `error_get_last` returns `NULL`.

The library assumes `error_get_last` will contain an array with a `message` key. But this is not the case in every PHP environment and framework.

This PR adds a fallback to address this issue. It doesn't change default behavior.

#### How to reproduce?

Create a fresh Laravel app, install cloudinary php, add a cloudinary url, and try to upload a non-existing file.

I published a test app to show and test the behavior, [here](https://github.com/einenlum/cloudinary-offset-error).

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes (but the bug cannot be reproduced without a Laravel environment)
- [] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
