### PR TITLE
feat: Slight performance improvements

### DIFF
--- a/src/Api/ApiClient.php
+++ b/src/Api/ApiClient.php
@@ -424,7 +424,12 @@ class ApiClient extends BaseApiClient
             ];
         }
 
-        return array_merge_recursive($clientConfig, $authConfig);
+        if (isset($authConfig['headers'])) {
+            $clientConfig['headers'] = array_merge($clientConfig['headers'], $authConfig['headers']);
+            unset($authConfig['headers']);
+        }
+
+        return array_merge($clientConfig, $authConfig);
     }
 
     /**

--- a/src/Asset/AssetFinalizerTrait.php
+++ b/src/Asset/AssetFinalizerTrait.php
@@ -186,7 +186,7 @@ trait AssetFinalizerTrait
     {
         $source = $this->asset->publicId(true);
 
-        if (! preg_match('/^https?:\//i', $source)) {
+        if (stripos($source, 'http:/') !== 0 && stripos($source, 'https:/') !== 0) {
             $source = rawurldecode($source);
         }
 
@@ -212,10 +212,14 @@ trait AssetFinalizerTrait
 
         if (empty($version) && $this->urlConfig->forceVersion
             && ! empty($this->asset->location)
-            && ! preg_match('/^https?:\//', $this->asset->publicId())
-            && ! preg_match('/^v\d+/', $this->asset->publicId())
         ) {
-            $version = '1';
+            $publicId = $this->asset->publicId();
+            if (strncmp($publicId, 'http:/', 6) !== 0
+                && strncmp($publicId, 'https:/', 7) !== 0
+                && ! preg_match('/^v\d+/', $publicId)
+            ) {
+                $version = '1';
+            }
         }
 
         return $version ? 'v' . $version : null;

--- a/src/Asset/AuthToken.php
+++ b/src/Asset/AuthToken.php
@@ -85,7 +85,13 @@ class AuthToken
      */
     public function configuration(mixed $configuration): static
     {
-        $tempConfiguration = new Configuration($configuration, false); // TODO: improve performance here
+        if ($configuration instanceof Configuration) {
+            $this->config = clone $configuration->authToken;
+
+            return $this;
+        }
+
+        $tempConfiguration = new Configuration($configuration, false);
 
         $this->config = $tempConfiguration->authToken;
 

--- a/src/Asset/BaseAsset.php
+++ b/src/Asset/BaseAsset.php
@@ -266,7 +266,15 @@ abstract class BaseAsset implements AssetInterface
      */
     public function configuration(Configuration|array $configuration): static
     {
-        $tempConfiguration = new Configuration($configuration, true); // TODO: improve performance here
+        if ($configuration instanceof Configuration) {
+            $this->cloud     = clone $configuration->cloud;
+            $this->urlConfig = clone $configuration->url;
+            $this->logging   = clone $configuration->logging;
+
+            return $this;
+        }
+
+        $tempConfiguration = new Configuration($configuration, true);
         $this->cloud       = $tempConfiguration->cloud;
         $this->urlConfig   = $tempConfiguration->url;
         $this->logging     = $tempConfiguration->logging;
@@ -372,7 +380,7 @@ abstract class BaseAsset implements AssetInterface
             if (! $includeEmptySections && empty(array_values($section)[0])) {
                 continue;
             }
-            $json = array_merge($json, $section);
+            $json += $section;
         }
 
         return $json;

--- a/src/Asset/Descriptor/AssetDescriptor.php
+++ b/src/Asset/Descriptor/AssetDescriptor.php
@@ -162,7 +162,7 @@ class AssetDescriptor implements AssetInterface
             return $this;
         }
 
-        if (preg_match('/[.\/]/', $suffix)) {
+        if (str_contains($suffix, '.') || str_contains($suffix, '/')) {
             throw new \UnexpectedValueException(static::class . '::$suffix must not include . or /');
         }
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -331,7 +331,7 @@ class Configuration implements ConfigurableInterface
             if (! $includeEmptySections && empty(array_values($section)[0])) {
                 continue;
             }
-            $json = array_merge($json, $section);
+            $json += $section;
         }
 
         return $json;

--- a/tests/Unit/Admin/OAuthTest.php
+++ b/tests/Unit/Admin/OAuthTest.php
@@ -43,6 +43,12 @@ final class OAuthTest extends UnitTestCase
                 'Authorization' => ['Bearer ' . self::FAKE_OAUTH_TOKEN]
             ]
         );
+
+        self::assertArrayHasKey(
+            'User-Agent',
+            $lastRequest->getHeaders(),
+            'User-Agent header must be present alongside Authorization when using OAuth token'
+        );
     }
 
     /**

--- a/tests/Unit/Configuration/ConfigurationTest.php
+++ b/tests/Unit/Configuration/ConfigurationTest.php
@@ -10,6 +10,7 @@
 
 namespace Cloudinary\Test\Unit\Configuration;
 
+use Cloudinary\Asset\Image;
 use Cloudinary\Configuration\Configuration;
 use Cloudinary\Test\Unit\UnitTestCase;
 use Cloudinary\Utils;
@@ -150,6 +151,30 @@ class ConfigurationTest extends UnitTestCase
         self::assertEquals(
             $expectedJsonConfig,
             json_encode(Configuration::fromJson($expectedJsonConfig))
+        );
+    }
+
+    public function testAssetConfigurationIsIndependentFromGlobalConfig()
+    {
+        $globalConfig = Configuration::instance();
+        $originalCloudName = $globalConfig->cloud->cloudName;
+        $originalSecure    = $globalConfig->url->secure;
+
+        $image = new Image('sample.png');
+
+        // Mutating the asset's config sections must not affect the global configuration
+        $image->cloud->cloudName = 'mutated_cloud';
+        $image->urlConfig->secure = ! $originalSecure;
+
+        self::assertEquals(
+            $originalCloudName,
+            $globalConfig->cloud->cloudName,
+            'Mutating asset cloud config must not affect the global Configuration'
+        );
+        self::assertEquals(
+            $originalSecure,
+            $globalConfig->url->secure,
+            'Mutating asset url config must not affect the global Configuration'
         );
     }
 }

--- a/tests/Unit/Upload/OAuthTest.php
+++ b/tests/Unit/Upload/OAuthTest.php
@@ -47,6 +47,12 @@ final class OAuthTest extends AssetTestCase
                 'Authorization' => ['Bearer ' . self::FAKE_OAUTH_TOKEN]
             ]
         );
+
+        self::assertArrayHasKey(
+            'User-Agent',
+            $lastRequest->getHeaders(),
+            'User-Agent header must be present alongside Authorization when using OAuth token'
+        );
     }
 
     /**

--- a/tools/benchmark.php
+++ b/tools/benchmark.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Micro-benchmark for hot paths in the Cloudinary PHP SDK.
+ *
+ * Usage:
+ *   php tools/benchmark.php
+ *
+ * Run on each branch/stash to compare before/after.
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Cloudinary\Asset\Image;
+use Cloudinary\Asset\Video;
+use Cloudinary\Configuration\Configuration;
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+putenv('CLOUDINARY_URL=cloudinary://api_key:api_secret@my_cloud');
+Configuration::instance()->init();
+Configuration::instance()->url->analytics(false);
+
+const ITERATIONS = 10_000;
+const RUNS       = 3;
+
+// ── Benchmark helpers ─────────────────────────────────────────────────────────
+
+function bench(string $label, callable $fn): void
+{
+    $times = [];
+
+    for ($run = 0; $run < RUNS; $run++) {
+        $start = hrtime(true);
+        for ($i = 0; $i < ITERATIONS; $i++) {
+            $fn();
+        }
+        $times[] = (hrtime(true) - $start) / 1e6; // ns → ms
+    }
+
+    $avg = array_sum($times) / count($times);
+    $min = min($times);
+    $max = max($times);
+
+    printf(
+        "  %-50s  avg: %7.2f ms  min: %7.2f ms  max: %7.2f ms\n",
+        $label,
+        $avg,
+        $min,
+        $max
+    );
+}
+
+// ── Scenarios ─────────────────────────────────────────────────────────────────
+
+echo str_repeat('─', 90) . "\n";
+echo sprintf("  Cloudinary PHP SDK benchmark — %d iterations × %d runs\n", ITERATIONS, RUNS);
+echo str_repeat('─', 90) . "\n";
+
+// 1. Asset construction (exercises configuration() fast path)
+bench('new Image($source)', function () {
+    $img = new Image('sample/image.jpg');
+});
+
+// 2. Asset construction + URL generation (exercises finalizeSource, finalizeVersion)
+bench('(string) new Image($source)', function () {
+    $img = (string) new Image('sample/image.jpg');
+});
+
+// 3. URL generation on a pre-built asset (isolates toUrl() overhead)
+$image = new Image('sample/image.jpg');
+bench('$image->toUrl()  [pre-built asset]', function () use ($image) {
+    $url = (string) $image->toUrl();
+});
+
+// 4. Asset with suffix (exercises setSuffix + finalizeAssetType)
+bench('new Image + setSuffix()', function () {
+    $img = new Image('sample/image.jpg');
+    $img->asset->suffix = 'my-seo-name';
+    $url = (string) $img->toUrl();
+});
+
+// 5. Video asset (different asset type path)
+bench('(string) new Video($source)', function () {
+    $img = (string) new Video('sample/video.mp4');
+});
+
+// 6. Configuration::jsonSerialize() (exercises array_merge → += fix)
+$config = Configuration::instance();
+bench('Configuration::jsonSerialize()', function () use ($config) {
+    $config->jsonSerialize();
+});
+
+// 7. Asset construction from Configuration array (slow path, for comparison)
+$configArray = $config->jsonSerialize();
+bench('new Image($source, $configArray)  [array config]', function () use ($configArray) {
+    $img = new Image('sample/image.jpg', $configArray);
+});
+
+echo str_repeat('─', 90) . "\n";


### PR DESCRIPTION
### Brief Summary of Changes

Several small performance improvements targeting the most common hot paths: asset construction, URL generation, and API requests. No behaviour change.

 - `BaseAsset::configuration()` and `AuthToken::configuration()`: added a fast path that clones config sections directly when a `Configuration` instance is passed, avoiding a full `new Configuration(...)` rebuild (7-object init + serialize/deserialize cycle) on every asset creation.
 - `Configuration::jsonSerialize()` and `BaseAsset::jsonSerialize()`: replaced `array_merge($json, $section)` in loops with the union operator `+=`, equivalent for unique string-keyed arrays.
 - `ApiClient::buildHttpClientConfig()`: replaced `array_merge_recursive` with an explicit header merge + `array_merge`, avoiding nested-array side effects and unnecessary overhead.
 - `AssetFinalizerTrait::finalizeSource()` / `finalizeVersion()`: replaced `preg_match` calls with `stripos`/`strncmp` (preserving original case-sensitivity per call site); eliminated a redundant double call to `publicId()` in `finalizeVersion()`.
 - `AssetDescriptor::setSuffix()`: replaced `preg_match('/[.\/]/')` with `str_contains`.

 #### What does this PR address?
 - [ ] GitHub issue (Add reference - #XX)
 - [x] Refactoring
 - [ ] New feature
 - [ ] Bug fix
 - [x] Adds more tests

 #### Are tests included?
 - [x] Yes
 - [ ] No

 #### Reviewer, please note:

 - `BaseAsset::configuration()` fast path uses `clone` instead of a serialize/deserialize round-trip. Independence from the source `Configuration` singleton is covered by the new `testAssetConfigurationIsIndependentFromGlobalConfig` test.
 - The `finalizeSource()` regex `/^https?:\//i` matches a **single** slash (e.g. `http:/`), not `://`. The `stripos` replacement preserves this exact semantics.
 - `finalizeVersion()` used a case-sensitive regex; `strncmp` preserves that, while `finalizeSource()` used `/i`; `stripos` preserves that.
 - OAuth tests are extended to assert that `User-Agent` is preserved alongside `Authorization` — this is the regression guard for the `buildHttpClientConfig()` change.

Edit: I added a benchmark tool, below are the results:
10 000 iterations × 3 runs averaged on each branch (`php tools/benchmark.php`).
 
 | Scenario | Before (`master`) | After | Gain |
 |---|---|---|---|
 | `new Image($source)` | 1238 ms | 21 ms | **x59.9** |
 | `(string) new Image($source)` | 1417 ms | 155 ms | **x9.1** |
 | `$image->toUrl()` *(pre-built asset)* | 152 ms | 132 ms | **-13%** |
 | `new Image + setSuffix()` | 1409 ms | 148 ms | **x9.5** |
 | `(string) new Video($source)` | 1406 ms | 153 ms | **x9.2** |
 | `Configuration::jsonSerialize()` | 296 ms | 290 ms | **-2%** |
 | `new Image($source, $configArray)` *(array slow path)* | 648 ms | 637 ms | **-2%** |
 
Main gain comes from the `configuration()` fast path: asset construction no longer triggers a full `new Configuration(...)` rebuild (7-object init + serialize/deserialize cycle) on every call. 
The `toUrl()` row on a pre-built asset isolates URL generation improvements independently of construction overhead.


 #### Checklist:
 - [x] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [x] I ran the full test suite before pushing the changes and all of the tests pass.